### PR TITLE
Feature habit scheduling foundation

### DIFF
--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -545,7 +545,7 @@ def calendar():
     cursor = conn.cursor()
 
     cursor.execute("""
-        SELECT id, habit_name, category, priority, created_date
+        SELECT id, habit_name, category, priority, created_date, schedule
         FROM habits
         WHERE user_id = ?
     """, (session["user_id"],))
@@ -573,11 +573,19 @@ def calendar():
     for habit in habits:
         habit_id = habit[0]
         habit_name = habit[1]
+        created_date = habit[4]
+        schedule = habit[5]
 
         data = []
 
         for day_string in last_7_days:
-            if (habit_id, day_string) in completed_set:
+            day_date = date.fromisoformat(day_string)
+
+            if day_string < created_date:
+                data.append(None)
+            elif not is_habit_scheduled_for_date(schedule, day_date):
+                data.append(None)
+            elif (habit_id, day_string) in completed_set:
                 data.append(1)
             else:
                 data.append(0)
@@ -587,6 +595,26 @@ def calendar():
             "data": data
         })
 
+    calendar_habits_by_date = {}
+
+    for week in month_days:
+        for day in week:
+            if day == 0:
+                continue
+
+            current_date = date(year, month, day)
+            full_date = current_date.isoformat()
+            visible_habits = []
+
+            for habit in habits:
+                if (
+                    full_date >= habit[4]
+                    and is_habit_scheduled_for_date(habit[5], current_date)
+                ):
+                    visible_habits.append(habit)
+
+            calendar_habits_by_date[full_date] = visible_habits
+
     conn.close()
 
     return render_template(
@@ -595,6 +623,7 @@ def calendar():
         month_days=month_days,
         habits=habits,
         completed_set=completed_set,
+        calendar_habits_by_date=calendar_habits_by_date,
         year=year,
         month=month,
         chart_labels=chart_labels,

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -779,31 +779,40 @@ def stats():
     )
     total_habits = cursor.fetchone()[0]
 
+    cursor.execute(
+        "SELECT id, created_date, schedule FROM habits WHERE user_id = ?",
+        (session["user_id"],)
+    )
+    user_habits = cursor.fetchall()
+
+    cursor.execute(
+        """
+        SELECT habit_id, completion_date
+        FROM habit_completions
+        WHERE user_id = ?
+        """,
+        (session["user_id"],)
+    )
+    completion_records = set(cursor.fetchall())
+
     weekly_progress = []
     active_days = 0
 
     for week_day in week_dates:
         day_string = week_day.isoformat()
 
-        cursor.execute(
-            """
-            SELECT COUNT(*)
-            FROM habit_completions
-            WHERE user_id = ? AND completion_date = ?
-            """,
-            (session["user_id"], day_string)
+        scheduled_habit_ids = [
+            habit_id
+            for habit_id, created_date, schedule in user_habits
+            if created_date <= day_string
+            and is_habit_scheduled_for_date(schedule, week_day)
+        ]
+        goal = len(scheduled_habit_ids)
+        completed = sum(
+            1
+            for habit_id in scheduled_habit_ids
+            if (habit_id, day_string) in completion_records
         )
-        completed = cursor.fetchone()[0]
-
-        cursor.execute(
-            """
-            SELECT COUNT(*)
-            FROM habits
-            WHERE user_id = ? AND created_date <= ?
-            """,
-            (session["user_id"], day_string)
-        )
-        goal = cursor.fetchone()[0]
 
         if goal > 0:
             active_days += 1
@@ -928,7 +937,7 @@ def habit_detail(habit_id):
     # Get habit info
     cursor.execute("""
         SELECT id, habit_name, category, priority,
-               target_value, target_unit, notes, created_date
+               target_value, target_unit, notes, created_date, schedule
         FROM habits
         WHERE id = ? AND user_id = ?
     """, (habit_id, session["user_id"]))
@@ -959,7 +968,11 @@ def habit_detail(habit_id):
 
         chart_labels.append(d.strftime("%a"))
 
-        if d_str in completion_set:
+        if d_str < habit[7]:
+            chart_values.append(None)
+        elif not is_habit_scheduled_for_date(habit[8], d):
+            chart_values.append(None)
+        elif d_str in completion_set:
             chart_values.append(1)
         else:
             chart_values.append(0)
@@ -981,6 +994,8 @@ def habit_detail(habit_id):
         chart_values=chart_values,
         month_days=month_days,
         month_name=month_name,
+        date=date,
+        is_habit_scheduled_for_date=is_habit_scheduled_for_date,
         year=year,
         month=month
     )

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -8,6 +8,40 @@ import calendar as cal
 app = Flask(__name__)
 app.secret_key = "habit_tracker_secret_key"
 
+WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+
+def ensure_column_exists(cursor, table_name, column_name, column_definition):
+    cursor.execute(f"PRAGMA table_info({table_name})")
+    existing_columns = [column[1] for column in cursor.fetchall()]
+
+    if column_name not in existing_columns:
+        cursor.execute(
+            f"ALTER TABLE {table_name} "
+            f"ADD COLUMN {column_name} {column_definition}"
+        )
+
+
+def parse_schedule(schedule_value):
+    if not schedule_value:
+        return []
+
+    return [
+        day.strip()
+        for day in schedule_value.split(",")
+        if day.strip()
+    ]
+
+
+def is_habit_scheduled_for_date(schedule_value, target_date):
+    scheduled_days = parse_schedule(schedule_value)
+
+    # Empty schedules represent legacy habits and should behave as daily.
+    if not scheduled_days:
+        return True
+
+    return target_date.strftime("%a") in scheduled_days
+
 
 def init_db():
     conn = sqlite3.connect("habit_tracker.db")
@@ -28,6 +62,7 @@ def init_db():
             user_id INTEGER NOT NULL,
             habit_name TEXT NOT NULL,
             category TEXT,
+            schedule TEXT,
             priority TEXT,
             target_value TEXT,
             target_unit TEXT,
@@ -36,6 +71,8 @@ def init_db():
             streak INTEGER DEFAULT 0
         )
     """)
+
+    ensure_column_exists(cursor, "habits", "schedule", "TEXT")
 
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS habit_completions (
@@ -314,6 +351,7 @@ def new_habit():
         habit_name = request.form["habit_name"]
         category = request.form["category"]
         priority = request.form["priority"]
+        schedule = ",".join(request.form.getlist("schedule"))
         target_value = request.form["target_value"]
         target_unit = request.form["target_unit"]
         notes = request.form["notes"]
@@ -324,12 +362,13 @@ def new_habit():
 
         cursor.execute("""
             INSERT INTO habits
-            (user_id, habit_name, category, priority, target_value, target_unit, notes, created_date)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (user_id, habit_name, category, schedule, priority, target_value, target_unit, notes, created_date)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             session["user_id"],
             habit_name,
             category,
+            schedule,
             priority,
             target_value,
             target_unit,
@@ -439,7 +478,7 @@ def edit_habit(habit_id):
         return redirect(url_for("dashboard"))
 
     cursor.execute("""
-        SELECT id, habit_name, category, priority, target_value, target_unit, notes, created_date
+        SELECT id, habit_name, category, schedule, priority, target_value, target_unit, notes, created_date
         FROM habits
         WHERE id = ? AND user_id = ?
     """, (habit_id, session["user_id"]))
@@ -451,7 +490,13 @@ def edit_habit(habit_id):
         flash("Habit not found.")
         return redirect(url_for("dashboard"))
 
-    return render_template("edit_habit.html", habit=habit)
+    selected_schedule = parse_schedule(habit[3])
+
+    return render_template(
+        "edit_habit.html",
+        habit=habit,
+        selected_schedule=selected_schedule
+    )
 
 
 @app.route("/delete_habit/<int:habit_id>")

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -180,7 +180,8 @@ def dashboard():
     if "user_id" not in session:
         return redirect(url_for("login"))
 
-    today = date.today().isoformat()
+    today_date = date.today()
+    today = today_date.isoformat()
 
     quotes = [
         "Small progress is still progress.",
@@ -200,7 +201,7 @@ def dashboard():
                    WHEN c.id IS NOT NULL THEN 'Completed'
                    ELSE 'Not Completed'
                END,
-               h.target_value, h.target_unit
+               h.target_value, h.target_unit, h.schedule
         FROM habits h
         LEFT JOIN habit_completions c
         ON h.id = c.habit_id
@@ -209,7 +210,10 @@ def dashboard():
         ORDER BY h.id DESC
     """, (today, session["user_id"]))
 
-    habits = cursor.fetchall()
+    habits = [
+        habit for habit in cursor.fetchall()
+        if is_habit_scheduled_for_date(habit[10], today_date)
+    ]
 
     total = len(habits)
     completed = len([h for h in habits if h[7] == "Completed"])
@@ -452,6 +456,7 @@ def edit_habit(habit_id):
     if request.method == "POST":
         habit_name = request.form["habit_name"]
         category = request.form["category"]
+        schedule = ",".join(request.form.getlist("schedule"))
         priority = request.form["priority"]
         target_value = request.form["target_value"]
         target_unit = request.form["target_unit"]
@@ -459,11 +464,12 @@ def edit_habit(habit_id):
 
         cursor.execute("""
             UPDATE habits
-            SET habit_name = ?, category = ?, priority = ?, target_value = ?, target_unit = ?, notes = ?
+            SET habit_name = ?, category = ?, schedule = ?, priority = ?, target_value = ?, target_unit = ?, notes = ?
             WHERE id = ? AND user_id = ?
         """, (
             habit_name,
             category,
+            schedule,
             priority,
             target_value,
             target_unit,

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -1422,6 +1422,29 @@ h1, h2, h3, h4, h5 {
     border-radius: 12px;
 }
 
+.weekday-selector {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.weekday-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: white;
+    border: 1px solid #dbe3f0;
+    border-radius: 999px;
+    padding: 10px 14px;
+    font-weight: 600;
+    color: #1f2937;
+    cursor: pointer;
+}
+
+.weekday-option input {
+    margin: 0;
+}
+
 @media (max-width: 900px) {
     .stats-metric-grid {
         grid-template-columns: 1fr;

--- a/Habit-tracker/templates/calendar.html
+++ b/Habit-tracker/templates/calendar.html
@@ -75,20 +75,18 @@
 
                                     {% set full_date = "%04d-%02d-%02d"|format(year, month, day) %}
 
-                                    {% for habit in habits %}
-                                        {% if full_date >= habit[4] %}
-                                            <div class="calendar-habit-card">
-                                                <div class="calendar-habit-name">
-                                                    {{ habit[1] }}
-                                                </div>
-
-                                                {% if (habit[0], full_date) in completed_set %}
-                                                    <span class="calendar-status done">Completed</span>
-                                                {% else %}
-                                                    <span class="calendar-status pending">Pending</span>
-                                                {% endif %}
+                                    {% for habit in calendar_habits_by_date.get(full_date, []) %}
+                                        <div class="calendar-habit-card">
+                                            <div class="calendar-habit-name">
+                                                {{ habit[1] }}
                                             </div>
-                                        {% endif %}
+
+                                            {% if (habit[0], full_date) in completed_set %}
+                                                <span class="calendar-status done">Completed</span>
+                                            {% else %}
+                                                <span class="calendar-status pending">Pending</span>
+                                            {% endif %}
+                                        </div>
                                     {% endfor %}
                                 {% endif %}
                             </td>

--- a/Habit-tracker/templates/edit_habit.html
+++ b/Habit-tracker/templates/edit_habit.html
@@ -68,10 +68,52 @@
                 <div class="col-md-6 mb-4">
                     <label class="form-label">Priority</label>
                     <select name="priority" class="form-control edit-input">
-                        <option value="High" {% if habit[3] == "High" %}selected{% endif %}>High</option>
-                        <option value="Medium" {% if habit[3] == "Medium" %}selected{% endif %}>Medium</option>
-                        <option value="Low" {% if habit[3] == "Low" %}selected{% endif %}>Low</option>
+                        <option value="High" {% if habit[4] == "High" %}selected{% endif %}>High</option>
+                        <option value="Medium" {% if habit[4] == "Medium" %}selected{% endif %}>Medium</option>
+                        <option value="Low" {% if habit[4] == "Low" %}selected{% endif %}>Low</option>
                     </select>
+                </div>
+            </div>
+
+            <div class="edit-goal-box mb-4">
+                <h4>Habit Schedule</h4>
+                <p>Choose the days this habit should appear. Leave all unchecked for an everyday habit.</p>
+
+                <div class="weekday-selector">
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Mon" {% if "Mon" in selected_schedule %}checked{% endif %}>
+                        <span>Mon</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Tue" {% if "Tue" in selected_schedule %}checked{% endif %}>
+                        <span>Tue</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Wed" {% if "Wed" in selected_schedule %}checked{% endif %}>
+                        <span>Wed</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Thu" {% if "Thu" in selected_schedule %}checked{% endif %}>
+                        <span>Thu</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Fri" {% if "Fri" in selected_schedule %}checked{% endif %}>
+                        <span>Fri</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Sat" {% if "Sat" in selected_schedule %}checked{% endif %}>
+                        <span>Sat</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Sun" {% if "Sun" in selected_schedule %}checked{% endif %}>
+                        <span>Sun</span>
+                    </label>
                 </div>
             </div>
 
@@ -87,7 +129,7 @@
                             step="0.1"
                             name="target_value"
                             class="form-control edit-input"
-                            value="{{ habit[4] }}"
+                            value="{{ habit[5] }}"
                             required
                         >
                     </div>
@@ -95,14 +137,14 @@
                     <div class="col-md-6 mb-3">
                         <label class="form-label">Target Unit</label>
                         <select name="target_unit" class="form-control edit-input">
-                            <option value="times" {% if habit[5] == "times" %}selected{% endif %}>Times</option>
-                            <option value="minutes" {% if habit[5] == "minutes" %}selected{% endif %}>Minutes</option>
-                            <option value="hours" {% if habit[5] == "hours" %}selected{% endif %}>Hours</option>
-                            <option value="steps" {% if habit[5] == "steps" %}selected{% endif %}>Steps</option>
-                            <option value="km" {% if habit[5] == "km" %}selected{% endif %}>Kilometres</option>
-                            <option value="litres" {% if habit[5] == "litres" %}selected{% endif %}>Litres</option>
-                            <option value="pages" {% if habit[5] == "pages" %}selected{% endif %}>Pages</option>
-                            <option value="tasks" {% if habit[5] == "tasks" %}selected{% endif %}>Tasks</option>
+                            <option value="times" {% if habit[6] == "times" %}selected{% endif %}>Times</option>
+                            <option value="minutes" {% if habit[6] == "minutes" %}selected{% endif %}>Minutes</option>
+                            <option value="hours" {% if habit[6] == "hours" %}selected{% endif %}>Hours</option>
+                            <option value="steps" {% if habit[6] == "steps" %}selected{% endif %}>Steps</option>
+                            <option value="km" {% if habit[6] == "km" %}selected{% endif %}>Kilometres</option>
+                            <option value="litres" {% if habit[6] == "litres" %}selected{% endif %}>Litres</option>
+                            <option value="pages" {% if habit[6] == "pages" %}selected{% endif %}>Pages</option>
+                            <option value="tasks" {% if habit[6] == "tasks" %}selected{% endif %}>Tasks</option>
                         </select>
                     </div>
                 </div>
@@ -114,11 +156,11 @@
                     name="notes"
                     class="form-control edit-input"
                     rows="4"
-                >{{ habit[6] }}</textarea>
+                >{{ habit[7] }}</textarea>
             </div>
 
             <div class="edit-created-box mb-4">
-                <strong>Created Date:</strong> {{ habit[7] }}
+                <strong>Created Date:</strong> {{ habit[8] }}
             </div>
 
             <div class="d-flex gap-2">

--- a/Habit-tracker/templates/habit_detail.html
+++ b/Habit-tracker/templates/habit_detail.html
@@ -102,7 +102,7 @@
 
                                     {% set full_date = "%04d-%02d-%02d"|format(year, month, day) %}
 
-                                    {% if full_date >= habit[7] %}
+                                    {% if full_date >= habit[7] and is_habit_scheduled_for_date(habit[8], date(year, month, day)) %}
                                         {% if full_date in completion_set %}
                                             <div class="habit-day-status done">Completed</div>
                                         {% else %}

--- a/Habit-tracker/templates/new_habit.html
+++ b/Habit-tracker/templates/new_habit.html
@@ -85,6 +85,50 @@
                 </div>
             </div>
 
+            <div class="card p-3 mb-3 bg-light">
+                <h5>Habit Schedule</h5>
+                <p class="text-muted mb-3">
+                    Choose the days this habit should appear. Leave all unchecked for an everyday habit.
+                </p>
+
+                <div class="weekday-selector">
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Mon">
+                        <span>Mon</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Tue">
+                        <span>Tue</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Wed">
+                        <span>Wed</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Thu">
+                        <span>Thu</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Fri">
+                        <span>Fri</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Sat">
+                        <span>Sat</span>
+                    </label>
+
+                    <label class="weekday-option">
+                        <input type="checkbox" name="schedule" value="Sun">
+                        <span>Sun</span>
+                    </label>
+                </div>
+            </div>
+
             <div class="mb-3">
                 <label>Notes</label>
                 <textarea name="notes" class="form-control" rows="3" placeholder="Optional notes about this goal..."></textarea>


### PR DESCRIPTION
## Summary
This PR adds weekday habit scheduling to the app.

Users can now select weekdays when creating or editing a habit, or leave the schedule blank to treat the habit as daily. The scheduling logic is now applied across the dashboard, calendar, stats, and habit detail pages.

## Changes
- added a `schedule` field to the `habits` table
- added weekday selection to create and edit habit forms
- saved and updated selected weekdays in the backend
- made dashboard, calendar, stats, and habit detail views schedule-aware
- kept empty schedules working as daily habits for existing data

## How To Test
1. Run the app and log in.
2. Create:
   - `Gym` on `Mon, Wed, Fri`
   - `Study` on `Tue, Thu`
   - `Drink Water` with no schedule selected
3. Check the dashboard and confirm only today’s scheduled habits are shown.
4. Edit a habit and confirm the selected weekdays can be changed and saved.
5. Check the calendar and confirm habits only appear on scheduled weekdays.
6. Check stats and confirm daily goals and percentages change by scheduled days.
7. Check a habit detail page and confirm the trend/history respects the saved schedule.

## Expected Result
Scheduled habits only appear on their selected weekdays, while blank schedules continue to behave like daily habits.
