### PR TITLE
Feature real streak logic

### DIFF
--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -43,6 +43,82 @@ def is_habit_scheduled_for_date(schedule_value, target_date):
     return target_date.strftime("%a") in scheduled_days
 
 
+def calculate_habit_streak(
+    schedule_value,
+    created_date,
+    completion_dates,
+    reference_date=None
+):
+    if reference_date is None:
+        reference_date = date.today()
+
+    if isinstance(created_date, str):
+        created_date = date.fromisoformat(created_date)
+
+    if reference_date < created_date:
+        return 0
+
+    completion_set = set(completion_dates)
+    streak = 0
+    streak_date = reference_date
+
+    while streak_date >= created_date:
+        if not is_habit_scheduled_for_date(schedule_value, streak_date):
+            streak_date -= timedelta(days=1)
+            continue
+
+        if streak_date.isoformat() not in completion_set:
+            break
+
+        streak += 1
+        streak_date -= timedelta(days=1)
+
+    return streak
+
+
+def recalculate_habit_streak(cursor, habit_id, user_id, reference_date=None):
+    cursor.execute(
+        """
+        SELECT schedule, created_date
+        FROM habits
+        WHERE id = ? AND user_id = ?
+        """,
+        (habit_id, user_id)
+    )
+    habit = cursor.fetchone()
+
+    if habit is None:
+        return 0
+
+    cursor.execute(
+        """
+        SELECT completion_date
+        FROM habit_completions
+        WHERE habit_id = ? AND user_id = ?
+        """,
+        (habit_id, user_id)
+    )
+    completion_dates = [row[0] for row in cursor.fetchall()]
+
+    streak = calculate_habit_streak(
+        habit[0],
+        habit[1],
+        completion_dates,
+        reference_date
+    )
+
+    cursor.execute(
+        """
+        UPDATE habits
+        SET streak = ?
+        WHERE id = ? AND user_id = ?
+        """,
+        (streak, habit_id, user_id)
+    )
+
+    return streak
+
+
 def init_db():
     conn = sqlite3.connect("habit_tracker.db")
     cursor = conn.cursor()
@@ -412,11 +488,7 @@ def complete_habit(habit_id):
             VALUES (?, ?, ?)
         """, (habit_id, session["user_id"], today))
 
-        cursor.execute("""
-            UPDATE habits
-            SET streak = streak + 1
-            WHERE id = ? AND user_id = ?
-        """, (habit_id, session["user_id"]))
+    recalculate_habit_streak(cursor, habit_id, session["user_id"])
 
     conn.commit()
     conn.close()

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -119,6 +119,38 @@ def recalculate_habit_streak(cursor, habit_id, user_id, reference_date=None):
     return streak
 
 
+def attach_calculated_streaks(cursor, habits, user_id, reference_date=None):
+    if not habits:
+        return habits
+
+    cursor.execute(
+        """
+        SELECT habit_id, completion_date
+        FROM habit_completions
+        WHERE user_id = ?
+        """,
+        (user_id,)
+    )
+
+    completion_map = {}
+    for habit_id, completion_date in cursor.fetchall():
+        completion_map.setdefault(habit_id, set()).add(completion_date)
+
+    habits_with_streaks = []
+    for habit in habits:
+        calculated_streak = calculate_habit_streak(
+            habit[10],
+            habit[5],
+            completion_map.get(habit[0], set()),
+            reference_date
+        )
+        habit_values = list(habit)
+        habit_values[6] = calculated_streak
+        habits_with_streaks.append(tuple(habit_values))
+
+    return habits_with_streaks
+
+
 def init_db():
     conn = sqlite3.connect("habit_tracker.db")
     cursor = conn.cursor()
@@ -290,6 +322,12 @@ def dashboard():
         habit for habit in cursor.fetchall()
         if is_habit_scheduled_for_date(habit[10], today_date)
     ]
+    habits = attach_calculated_streaks(
+        cursor,
+        habits,
+        session["user_id"],
+        today_date
+    )
 
     total = len(habits)
     completed = len([h for h in habits if h[7] == "Completed"])
@@ -511,6 +549,8 @@ def reset_habit(habit_id):
         WHERE habit_id = ? AND user_id = ? AND completion_date = ?
     """, (habit_id, session["user_id"], today))
 
+    recalculate_habit_streak(cursor, habit_id, session["user_id"])
+
     conn.commit()
     conn.close()
 
@@ -549,6 +589,8 @@ def edit_habit(habit_id):
             habit_id,
             session["user_id"]
         ))
+
+        recalculate_habit_streak(cursor, habit_id, session["user_id"])
 
         conn.commit()
         conn.close()

--- a/Habit-tracker/test_streak_logic.py
+++ b/Habit-tracker/test_streak_logic.py
@@ -1,0 +1,60 @@
+import unittest
+from datetime import date
+
+from app import calculate_habit_streak
+
+
+class CalculateHabitStreakTests(unittest.TestCase):
+    def test_daily_streak_counts_consecutive_completions(self):
+        streak = calculate_habit_streak(
+            "",
+            "2026-05-01",
+            {"2026-05-01", "2026-05-02", "2026-05-03"},
+            date(2026, 5, 3)
+        )
+
+        self.assertEqual(streak, 3)
+
+    def test_daily_streak_resets_after_a_missed_day(self):
+        streak = calculate_habit_streak(
+            "",
+            "2026-05-01",
+            {"2026-05-01", "2026-05-02"},
+            date(2026, 5, 3)
+        )
+
+        self.assertEqual(streak, 0)
+
+    def test_scheduled_streak_skips_unscheduled_days(self):
+        streak = calculate_habit_streak(
+            "Mon,Wed,Fri",
+            "2026-04-27",
+            {"2026-04-27", "2026-04-29", "2026-05-01"},
+            date(2026, 5, 2)
+        )
+
+        self.assertEqual(streak, 3)
+
+    def test_scheduled_streak_breaks_on_missed_scheduled_day(self):
+        streak = calculate_habit_streak(
+            "Mon,Wed,Fri",
+            "2026-04-27",
+            {"2026-04-27"},
+            date(2026, 4, 30)
+        )
+
+        self.assertEqual(streak, 0)
+
+    def test_days_before_creation_do_not_count_as_missed(self):
+        streak = calculate_habit_streak(
+            "Mon,Wed,Fri",
+            "2026-05-01",
+            {"2026-05-01"},
+            date(2026, 5, 2)
+        )
+
+        self.assertEqual(streak, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR improves streak tracking so it reflects actual habit completion history instead of only increasing when a habit is marked complete. It makes streaks more reliable by recalculating them based on recorded completions and scheduled habit days.

## What Changed
- Added tests for streak logic
- Replaced simple streak incrementing with real streak recalculation
- Updated habit flows so streaks stay accurate after completing, resetting, or editing a habit
- Updated dashboard streak display to use recalculated values

## Why This Change Was Needed
Previously, the streak value only increased when a habit was completed. This meant streaks could become inaccurate if:
- a required day was missed
- a completion was reset
- a habit schedule was changed

This PR fixes that so users can trust the streak feature as a core part of the app.

## Tests
Added tests for:
- consecutive daily completions
- missed-day streak resets
- scheduled habits skipping non-scheduled days
- missed scheduled days breaking the streak
- newly created habits not being penalised for days before creation

## Manual Checks
- Complete a habit on consecutive days and confirm the streak increases correctly
- Reset a completion and confirm the streak updates correctly
- Edit a habit schedule and confirm streak behavior still matches scheduled days
- Check that dashboard streak values match real completion history