### PR TITLE
Feature real streak logic

### DIFF
--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -50,6 +50,82 @@ def format_schedule_label(schedule_value):
     return ", ".join(scheduled_days)
 
 
+def calculate_habit_streak(
+    schedule_value,
+    created_date,
+    completion_dates,
+    reference_date=None
+):
+    if reference_date is None:
+        reference_date = date.today()
+
+    if isinstance(created_date, str):
+        created_date = date.fromisoformat(created_date)
+
+    if reference_date < created_date:
+        return 0
+
+    completion_set = set(completion_dates)
+    streak = 0
+    streak_date = reference_date
+
+    while streak_date >= created_date:
+        if not is_habit_scheduled_for_date(schedule_value, streak_date):
+            streak_date -= timedelta(days=1)
+            continue
+
+        if streak_date.isoformat() not in completion_set:
+            break
+
+        streak += 1
+        streak_date -= timedelta(days=1)
+
+    return streak
+
+
+def recalculate_habit_streak(cursor, habit_id, user_id, reference_date=None):
+    cursor.execute(
+        """
+        SELECT schedule, created_date
+        FROM habits
+        WHERE id = ? AND user_id = ?
+        """,
+        (habit_id, user_id)
+    )
+    habit = cursor.fetchone()
+
+    if habit is None:
+        return 0
+
+    cursor.execute(
+        """
+        SELECT completion_date
+        FROM habit_completions
+        WHERE habit_id = ? AND user_id = ?
+        """,
+        (habit_id, user_id)
+    )
+    completion_dates = [row[0] for row in cursor.fetchall()]
+
+    streak = calculate_habit_streak(
+        habit[0],
+        habit[1],
+        completion_dates,
+        reference_date
+    )
+
+    cursor.execute(
+        """
+        UPDATE habits
+        SET streak = ?
+        WHERE id = ? AND user_id = ?
+        """,
+        (streak, habit_id, user_id)
+    )
+
+    return streak
+
+
 def get_habits_for_user_with_today_status(user_id, target_date):
     day_string = target_date.isoformat()
     conn = sqlite3.connect("habit_tracker.db")
@@ -513,11 +589,7 @@ def complete_habit(habit_id):
             VALUES (?, ?, ?)
         """, (habit_id, session["user_id"], today))
 
-        cursor.execute("""
-            UPDATE habits
-            SET streak = streak + 1
-            WHERE id = ? AND user_id = ?
-        """, (habit_id, session["user_id"]))
+    recalculate_habit_streak(cursor, habit_id, session["user_id"])
 
     conn.commit()
     conn.close()
@@ -539,6 +611,8 @@ def reset_habit(habit_id):
         DELETE FROM habit_completions
         WHERE habit_id = ? AND user_id = ? AND completion_date = ?
     """, (habit_id, session["user_id"], today))
+
+    recalculate_habit_streak(cursor, habit_id, session["user_id"])
 
     conn.commit()
     conn.close()
@@ -578,6 +652,8 @@ def edit_habit(habit_id):
             habit_id,
             session["user_id"]
         ))
+
+        recalculate_habit_streak(cursor, habit_id, session["user_id"])
 
         conn.commit()
         conn.close()

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -126,6 +126,38 @@ def recalculate_habit_streak(cursor, habit_id, user_id, reference_date=None):
     return streak
 
 
+def attach_calculated_streaks(cursor, habits, user_id, reference_date=None):
+    if not habits:
+        return habits
+
+    cursor.execute(
+        """
+        SELECT habit_id, completion_date
+        FROM habit_completions
+        WHERE user_id = ?
+        """,
+        (user_id,)
+    )
+
+    completion_map = {}
+    for habit_id, completion_date in cursor.fetchall():
+        completion_map.setdefault(habit_id, set()).add(completion_date)
+
+    habits_with_streaks = []
+    for habit in habits:
+        calculated_streak = calculate_habit_streak(
+            habit[10],
+            habit[5],
+            completion_map.get(habit[0], set()),
+            reference_date
+        )
+        habit_values = list(habit)
+        habit_values[6] = calculated_streak
+        habits_with_streaks.append(tuple(habit_values))
+
+    return habits_with_streaks
+
+
 def get_habits_for_user_with_today_status(user_id, target_date):
     day_string = target_date.isoformat()
     conn = sqlite3.connect("habit_tracker.db")
@@ -148,6 +180,7 @@ def get_habits_for_user_with_today_status(user_id, target_date):
     """, (day_string, user_id))
 
     habits = cursor.fetchall()
+    habits = attach_calculated_streaks(cursor, habits, user_id, target_date)
     conn.close()
     return habits
 


### PR DESCRIPTION
## Summary
This PR improves habit streak tracking so it reflects real completion history instead of only increasing when a habit is marked complete.

## What Changed
- Recalculated streaks from habit completion history
- Made streaks respect each habit’s schedule
- Updated complete, reset, and edit flows to keep streaks accurate
- Updated dashboard and Active Habits views to show recalculated streak values

## Why This Change Was Needed
Previously, streaks only increased when a habit was completed. This meant streak values could become inaccurate if:
- a required day was missed
- a completion was reset
- a habit schedule was edited

This PR fixes that so streak values better reflect actual user consistency.

## Manual Checks
- Complete a habit on consecutive scheduled days and confirm the streak increases correctly
- Reset a completion and confirm the streak updates correctly
- Edit a habit schedule and confirm streak behavior still matches the new schedule
- Check that dashboard and Active Habits pages show the correct streak values