### PR TITLE
Dashboard analytics

### DIFF
--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -9,6 +9,16 @@ app = Flask(__name__)
 app.secret_key = "habit_tracker_secret_key"
 
 WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+# Dashboard analytics rules are defined centrally so every future card
+# and ranking uses the same thresholds and time windows.
+DASHBOARD_ANALYTICS_WINDOW_DAYS = 7
+DASHBOARD_TOP_HABIT_MIN_SCHEDULED_DAYS = 2
+DASHBOARD_TOP_CATEGORY_MIN_SCHEDULED_DAYS = 2
+DASHBOARD_AT_RISK_RATE_THRESHOLD = 60
+DASHBOARD_STREAK_COOLDOWN_MIN_BEST_STREAK = 3
+
+
 def ensure_column_exists(cursor, table_name, column_name, column_definition):
     cursor.execute(f"PRAGMA table_info({table_name})")
     existing_columns = [column[1] for column in cursor.fetchall()]
@@ -60,6 +70,14 @@ def parse_optional_date(date_value, fallback_date):
         return fallback_date
 
 
+def get_trailing_dates(reference_date, length, trailing_offset=0):
+    """Return ascending dates for a trailing window ending before offset days."""
+    return [
+        reference_date - timedelta(days=offset)
+        for offset in range(length + trailing_offset - 1, trailing_offset - 1, -1)
+    ]
+
+
 def calculate_habit_streak(
     schedule_value,
     created_date,
@@ -91,6 +109,119 @@ def calculate_habit_streak(
         streak_date -= timedelta(days=1)
 
     return streak
+
+
+def calculate_completion_day_streak(completion_dates, reference_date=None):
+    """Count consecutive calendar days with at least one habit completion."""
+    if reference_date is None:
+        reference_date = date.today()
+
+    completion_set = set(completion_dates)
+    streak = 0
+    streak_date = reference_date
+
+    while streak_date.isoformat() in completion_set:
+        streak += 1
+        streak_date -= timedelta(days=1)
+
+    return streak
+
+
+def summarize_scheduled_progress(habits, completion_records, target_dates):
+    """Average daily completion % across days with scheduled habits only."""
+    progress = []
+    active_days = 0
+
+    for target_date in target_dates:
+        day_string = target_date.isoformat()
+        scheduled_habit_ids = [
+            habit_id
+            for habit_id, created_date, schedule in habits
+            if created_date <= day_string
+            and is_habit_scheduled_for_date(schedule, target_date)
+        ]
+        goal = len(scheduled_habit_ids)
+        completed = sum(
+            1
+            for habit_id in scheduled_habit_ids
+            if (habit_id, day_string) in completion_records
+        )
+
+        if goal > 0:
+            active_days += 1
+
+        progress.append({
+            "label": WEEKDAY_NAMES[target_date.weekday()],
+            "completed": completed,
+            "goal": goal,
+            "percentage": 0 if goal == 0 else int((completed / goal) * 100)
+        })
+
+    average_progress = 0
+    if active_days > 0:
+        average_progress = int(
+            sum(day["percentage"] for day in progress) / active_days
+        )
+
+    return progress, average_progress, active_days
+
+
+def summarize_week_over_week_change(
+    current_average,
+    previous_average,
+    current_active_days,
+    previous_active_days
+):
+    """Describe weekly movement using the same scheduled-day completion rule."""
+    if current_active_days == 0:
+        return "No scheduled habits this week yet."
+
+    if previous_active_days == 0:
+        return "First active week with scheduled habit data."
+
+    delta = current_average - previous_average
+    if delta > 0:
+        return f"Up {delta} pts vs last week"
+
+    if delta < 0:
+        return f"Down {abs(delta)} pts vs last week"
+
+    return "Flat vs last week"
+
+
+def should_rank_dashboard_habit(scheduled_days):
+    """Only rank habits with enough scheduled check-ins to compare fairly."""
+    return scheduled_days >= DASHBOARD_TOP_HABIT_MIN_SCHEDULED_DAYS
+
+
+def should_rank_dashboard_category(scheduled_days):
+    """Only rank categories once they have enough scheduled habit volume."""
+    return scheduled_days >= DASHBOARD_TOP_CATEGORY_MIN_SCHEDULED_DAYS
+
+
+def classify_dashboard_habit_risk(
+    *,
+    scheduled_today,
+    completed_today,
+    weekly_rate,
+    current_streak,
+    best_streak
+):
+    """Flag habits that are due today, below pace, or losing momentum."""
+    if scheduled_today and not completed_today:
+        return "due_today"
+
+    if weekly_rate < DASHBOARD_AT_RISK_RATE_THRESHOLD:
+        return "below_pace"
+
+    if (
+        best_streak >= DASHBOARD_STREAK_COOLDOWN_MIN_BEST_STREAK
+        and current_streak == 0
+        and not completed_today
+    ):
+        return "cooling_off"
+
+    return None
 
 
 def recalculate_habit_streak(cursor, habit_id, user_id, reference_date=None):
@@ -1013,8 +1144,7 @@ def stats():
         return redirect(url_for("login"))
 
     today = date.today()
-    week_dates = [today - timedelta(days=offset) for offset in range(6, -1, -1)]
-    week_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    week_dates = get_trailing_dates(today, DASHBOARD_ANALYTICS_WINDOW_DAYS)
 
     conn = sqlite3.connect("habit_tracker.db")
     cursor = conn.cursor()
@@ -1047,40 +1177,11 @@ def stats():
     )
     completion_records = set(cursor.fetchall())
 
-    weekly_progress = []
-    active_days = 0
-
-    for week_day in week_dates:
-        day_string = week_day.isoformat()
-
-        scheduled_habit_ids = [
-            habit_id
-            for habit_id, created_date, schedule in user_habits
-            if created_date <= day_string
-            and is_habit_scheduled_for_date(schedule, week_day)
-        ]
-        goal = len(scheduled_habit_ids)
-        completed = sum(
-            1
-            for habit_id in scheduled_habit_ids
-            if (habit_id, day_string) in completion_records
-        )
-
-        if goal > 0:
-            active_days += 1
-
-        weekly_progress.append({
-            "label": week_labels[week_day.weekday()],
-            "completed": completed,
-            "goal": goal,
-            "percentage": 0 if goal == 0 else int((completed / goal) * 100)
-        })
-
-    average_progress = 0
-    if active_days > 0:
-        average_progress = int(
-            sum(day["percentage"] for day in weekly_progress) / active_days
-        )
+    weekly_progress, average_progress, _ = summarize_scheduled_progress(
+        user_habits,
+        completion_records,
+        week_dates
+    )
 
     cursor.execute(
         """
@@ -1094,13 +1195,7 @@ def stats():
     )
     completion_days = [row[0] for row in cursor.fetchall()]
 
-    current_streak = 0
-    streak_cursor = today
-    completion_set = set(completion_days)
-
-    while streak_cursor.isoformat() in completion_set:
-        current_streak += 1
-        streak_cursor -= timedelta(days=1)
+    current_streak = calculate_completion_day_streak(completion_days, today)
 
     best_day = {"label": "No data", "completed": 0, "goal": 0}
     if weekly_progress:

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -78,6 +78,14 @@ def get_trailing_dates(reference_date, length, trailing_offset=0):
     ]
 
 
+def get_week_dates_sunday_first(reference_date, week_offset=0):
+    """Return one calendar week in Sun-Sat order for the reference date."""
+    days_since_sunday = (reference_date.weekday() + 1) % 7
+    week_start = reference_date - timedelta(days=days_since_sunday)
+    week_start -= timedelta(days=week_offset * 7)
+    return [week_start + timedelta(days=offset) for offset in range(7)]
+
+
 def calculate_habit_streak(
     schedule_value,
     created_date,
@@ -161,12 +169,30 @@ def calculate_longest_habit_streak(
     return longest_streak
 
 
-def summarize_scheduled_progress(habits, completion_records, target_dates):
+def summarize_scheduled_progress(
+    habits,
+    completion_records,
+    target_dates,
+    available_through_date=None
+):
     """Average daily completion % across days with scheduled habits only."""
     progress = []
     active_days = 0
 
     for target_date in target_dates:
+        if (
+            available_through_date is not None
+            and target_date > available_through_date
+        ):
+            progress.append({
+                "label": target_date.strftime("%a"),
+                "completed": 0,
+                "goal": 0,
+                "percentage": 0,
+                "is_future": True
+            })
+            continue
+
         day_string = target_date.isoformat()
         scheduled_habit_ids = [
             habit_id
@@ -185,10 +211,11 @@ def summarize_scheduled_progress(habits, completion_records, target_dates):
             active_days += 1
 
         progress.append({
-            "label": WEEKDAY_NAMES[target_date.weekday()],
+            "label": target_date.strftime("%a"),
             "completed": completed,
             "goal": goal,
-            "percentage": 0 if goal == 0 else int((completed / goal) * 100)
+            "percentage": 0 if goal == 0 else int((completed / goal) * 100),
+            "is_future": False
         })
 
     average_progress = 0
@@ -215,12 +242,12 @@ def summarize_week_over_week_change(
 
     delta = current_average - previous_average
     if delta > 0:
-        return f"Up {delta} pts vs last week"
+        return f"{delta} percentage points better than last week"
 
     if delta < 0:
-        return f"Down {abs(delta)} pts vs last week"
+        return f"{abs(delta)} percentage points behind last week"
 
-    return "Flat vs last week"
+    return "Matching last week"
 
 
 def should_rank_dashboard_habit(scheduled_days):
@@ -519,12 +546,8 @@ def build_progress_snapshot(user_id, reference_date=None):
         reference_date = date.today()
 
     today_string = reference_date.isoformat()
-    week_dates = get_trailing_dates(reference_date, DASHBOARD_ANALYTICS_WINDOW_DAYS)
-    previous_week_dates = get_trailing_dates(
-        reference_date,
-        DASHBOARD_ANALYTICS_WINDOW_DAYS,
-        trailing_offset=DASHBOARD_ANALYTICS_WINDOW_DAYS
-    )
+    week_dates = get_week_dates_sunday_first(reference_date)
+    previous_week_dates = get_week_dates_sunday_first(reference_date, week_offset=1)
 
     conn = sqlite3.connect("habit_tracker.db")
     cursor = conn.cursor()
@@ -565,12 +588,14 @@ def build_progress_snapshot(user_id, reference_date=None):
     weekly_progress, weekly_average, active_days = summarize_scheduled_progress(
         progress_habits,
         completion_records,
-        week_dates
+        week_dates,
+        available_through_date=reference_date
     )
     _, previous_week_average, previous_active_days = summarize_scheduled_progress(
         progress_habits,
         completion_records,
-        previous_week_dates
+        previous_week_dates,
+        available_through_date=previous_week_dates[-1]
     )
 
     habit_summaries = []
@@ -594,6 +619,9 @@ def build_progress_snapshot(user_id, reference_date=None):
         scheduled_days = 0
         completed_days = 0
         for week_day in week_dates:
+            if week_day > reference_date:
+                continue
+
             day_string = week_day.isoformat()
             if created_date > day_string:
                 continue
@@ -663,9 +691,10 @@ def build_progress_snapshot(user_id, reference_date=None):
         })
 
     best_day = {"label": "No data", "completed": 0, "goal": 0}
-    if weekly_progress:
+    completed_week_days = [day for day in weekly_progress if not day["is_future"]]
+    if completed_week_days:
         best_day = max(
-            weekly_progress,
+            completed_week_days,
             key=lambda item: (item["percentage"], item["completed"])
         )
 
@@ -847,7 +876,6 @@ def dashboard():
 
     total = len(habits)
     completed = len([h for h in habits if h[7] == "Completed"])
-    percentage = int((completed / total) * 100) if total > 0 else 0
     reminders = [h for h in habits if h[7] == "Not Completed"]
     preview_habits = habits[:3]
 
@@ -898,7 +926,6 @@ def dashboard():
         habits=habits,
         total=total,
         completed=completed,
-        percentage=percentage,
         reminders=reminders,
         preview_habits=preview_habits,
         quote=random.choice(quotes),

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -320,6 +320,65 @@ def summarize_dashboard_risk(habit_summaries):
     }
 
 
+def build_dashboard_focus_items(habit_summaries):
+    """Select the most actionable habits to surface in the dashboard focus panel."""
+    risk_priority = {
+        "due_today": 0,
+        "below_pace": 1,
+        "cooling_off": 2
+    }
+    reason_labels = {
+        "due_today": "Due today",
+        "below_pace": "Below pace",
+        "cooling_off": "Cooling off"
+    }
+
+    focus_candidates = []
+    for habit in habit_summaries:
+        risk_code = habit["risk_code"]
+        if risk_code not in risk_priority:
+            continue
+
+        detail = ""
+        if risk_code == "due_today":
+            detail = (
+                f"{habit['completed_days']}/{habit['scheduled_days']} completed "
+                f"this week in {habit['category']}."
+            )
+        elif risk_code == "below_pace":
+            detail = (
+                f"{habit['weekly_rate']}% this week "
+                f"({habit['completed_days']}/{habit['scheduled_days']}) in "
+                f"{habit['category']}."
+            )
+        else:
+            detail = (
+                f"Best streak {habit['best_streak']} days, current streak "
+                f"{habit['current_streak']} in {habit['category']}."
+            )
+
+        focus_candidates.append({
+            "id": habit["id"],
+            "name": habit["name"],
+            "reason": reason_labels[risk_code],
+            "detail": detail,
+            "risk_code": risk_code,
+            "priority": risk_priority[risk_code],
+            "weekly_rate": habit["weekly_rate"],
+            "current_streak": habit["current_streak"]
+        })
+
+    return sorted(
+        focus_candidates,
+        key=lambda habit: (
+            habit["priority"],
+            habit["weekly_rate"],
+            habit["current_streak"],
+            habit["name"].lower()
+        )
+    )[:3]
+
+
 def classify_dashboard_habit_risk(
     *,
     scheduled_today,
@@ -628,6 +687,7 @@ def build_progress_snapshot(user_id, reference_date=None):
         "has_scheduled_data": active_days > 0,
         "best_day": best_day,
         "at_risk": summarize_dashboard_risk(habit_summaries),
+        "focus_items": build_dashboard_focus_items(habit_summaries),
         "top_habit": select_top_dashboard_habit(habit_summaries),
         "habit_summaries": habit_summaries,
         "category_summaries": category_summaries

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -277,6 +277,49 @@ def select_top_dashboard_habit(habit_summaries):
     }
 
 
+def summarize_dashboard_risk(habit_summaries):
+    """Summarize how many habits currently need attention on the dashboard."""
+    risk_counts = {
+        "due_today": 0,
+        "below_pace": 0,
+        "cooling_off": 0
+    }
+
+    for habit in habit_summaries:
+        risk_code = habit["risk_code"]
+        if risk_code in risk_counts:
+            risk_counts[risk_code] += 1
+
+    total_flagged = sum(risk_counts.values())
+    if total_flagged == 0:
+        return {
+            "count": 0,
+            "summary": "No habits flagged",
+            "detail": "Nothing is currently due, below pace, or cooling off."
+        }
+
+    if risk_counts["due_today"] > 0:
+        summary = f"{risk_counts['due_today']} due today"
+    elif risk_counts["below_pace"] > 0:
+        summary = f"{risk_counts['below_pace']} below pace"
+    else:
+        summary = f"{risk_counts['cooling_off']} cooling off"
+
+    detail_parts = []
+    if risk_counts["due_today"] > 0:
+        detail_parts.append(f"{risk_counts['due_today']} due today")
+    if risk_counts["below_pace"] > 0:
+        detail_parts.append(f"{risk_counts['below_pace']} below pace")
+    if risk_counts["cooling_off"] > 0:
+        detail_parts.append(f"{risk_counts['cooling_off']} cooling off")
+
+    return {
+        "count": total_flagged,
+        "summary": summary,
+        "detail": ", ".join(detail_parts)
+    }
+
+
 def classify_dashboard_habit_risk(
     *,
     scheduled_today,
@@ -584,6 +627,7 @@ def build_progress_snapshot(user_id, reference_date=None):
         ),
         "has_scheduled_data": active_days > 0,
         "best_day": best_day,
+        "at_risk": summarize_dashboard_risk(habit_summaries),
         "top_habit": select_top_dashboard_habit(habit_summaries),
         "habit_summaries": habit_summaries,
         "category_summaries": category_summaries

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -135,6 +135,29 @@ def calculate_completion_day_streak(completion_dates, reference_date=None):
     return streak
 
 
+def calculate_longest_completion_day_streak(completion_dates):
+    """Track the best consecutive completion-day streak across all habits."""
+    if not completion_dates:
+        return 0
+
+    completion_days = sorted({
+        date.fromisoformat(completion_date)
+        for completion_date in completion_dates
+    })
+
+    longest_streak = 1
+    current_streak = 1
+
+    for index in range(1, len(completion_days)):
+        if completion_days[index] - completion_days[index - 1] == timedelta(days=1):
+            current_streak += 1
+            longest_streak = max(longest_streak, current_streak)
+        else:
+            current_streak = 1
+
+    return longest_streak
+
+
 def calculate_longest_habit_streak(
     schedule_value,
     created_date,
@@ -344,6 +367,103 @@ def summarize_dashboard_risk(habit_summaries):
         "count": total_flagged,
         "summary": summary,
         "detail": ", ".join(detail_parts)
+    }
+
+
+def build_streak_progress_summary(
+    current_streak,
+    personal_best_streak,
+    habit_summaries,
+    weekly_average,
+    weekly_change_summary
+):
+    """Create a dashboard-friendly streak progress summary."""
+    milestones = [3, 7, 14, 21, 30]
+    next_goal = milestones[-1]
+    for milestone in milestones:
+        if current_streak < milestone:
+            next_goal = milestone
+            break
+    else:
+        extra_weeks = max(1, ((current_streak - milestones[-1]) // 7) + 1)
+        next_goal = milestones[-1] + (extra_weeks * 7)
+
+    progress_percentage = 0
+    if next_goal > 0:
+        progress_percentage = min(100, int((current_streak / next_goal) * 100))
+
+    carrying_habit = {
+        "name": "No habit is carrying it yet",
+        "current_streak": 0,
+        "category": "Build a run first"
+    }
+    if habit_summaries:
+        carrying_habit = max(
+            habit_summaries,
+            key=lambda habit: (
+                habit["current_streak"],
+                habit["best_streak"],
+                habit["weekly_rate"],
+                habit["name"].lower()
+            )
+        )
+        if carrying_habit["current_streak"] <= 0:
+            carrying_habit = {
+                "name": "No habit is carrying it yet",
+                "current_streak": 0,
+                "category": "Build a run first"
+            }
+
+    personal_best_streak = max(personal_best_streak, current_streak)
+    if personal_best_streak <= current_streak:
+        days_to_personal_best = 0
+        personal_best_label = "Personal best matched"
+        personal_best_detail = (
+            "This run is already matching your best streak so far."
+            if current_streak > 0 else
+            "Complete a habit streak to set your first personal best."
+        )
+    else:
+        days_to_personal_best = personal_best_streak - current_streak
+        personal_best_label = "Days to personal best"
+        personal_best_detail = (
+            f"{days_to_personal_best} more day"
+            f"{'' if days_to_personal_best == 1 else 's'} to match {personal_best_streak}."
+        )
+
+    if current_streak <= 0:
+        headline = "Start a new streak"
+        detail = "Complete today's habits to start building momentum again."
+    else:
+        headline = "Momentum is building"
+        detail = (
+            f"Stay with it and push toward your {next_goal}-day milestone."
+        )
+
+    return {
+        "current": current_streak,
+        "next_goal": next_goal,
+        "progress_percentage": progress_percentage,
+        "headline": headline,
+        "detail": detail,
+        "current_label": (
+            f"{current_streak} day streak"
+            if current_streak > 0 else
+            "No streak yet"
+        ),
+        "next_milestone_label": f"{next_goal}-day milestone",
+        "personal_best": personal_best_streak,
+        "days_to_personal_best": days_to_personal_best,
+        "personal_best_label": personal_best_label,
+        "personal_best_detail": personal_best_detail,
+        "carrying_habit_name": carrying_habit["name"],
+        "carrying_habit_detail": (
+            f"{carrying_habit['current_streak']}-day streak in {carrying_habit['category']}"
+            if carrying_habit["current_streak"] > 0 else
+            "Complete a few habits in a row and one will lead here."
+        ),
+        "weekly_completion_value": weekly_average,
+        "weekly_completion_trend": weekly_change_summary
     }
 
 
@@ -698,26 +818,39 @@ def build_progress_snapshot(user_id, reference_date=None):
             key=lambda item: (item["percentage"], item["completed"])
         )
 
+    completion_day_streak = calculate_completion_day_streak(
+        completion_days,
+        reference_date
+    )
+    personal_best_streak = calculate_longest_completion_day_streak(
+        completion_days
+    )
+    weekly_change_summary = summarize_week_over_week_change(
+        weekly_average,
+        previous_week_average,
+        active_days,
+        previous_active_days
+    )
+
     return {
         "reference_date": today_string,
         "weekly_progress": weekly_progress,
         "weekly_average": weekly_average,
         "previous_week_average": previous_week_average,
-        "weekly_change_summary": summarize_week_over_week_change(
-            weekly_average,
-            previous_week_average,
-            active_days,
-            previous_active_days
-        ),
-        "current_streak": calculate_completion_day_streak(
-            completion_days,
-            reference_date
-        ),
+        "weekly_change_summary": weekly_change_summary,
+        "current_streak": completion_day_streak,
         "has_scheduled_data": active_days > 0,
         "best_day": best_day,
         "at_risk": summarize_dashboard_risk(habit_summaries),
         "focus_items": build_dashboard_focus_items(habit_summaries),
         "top_habit": select_top_dashboard_habit(habit_summaries),
+        "streak_summary": build_streak_progress_summary(
+            completion_day_streak,
+            personal_best_streak,
+            habit_summaries,
+            weekly_average,
+            weekly_change_summary
+        ),
         "habit_summaries": habit_summaries,
         "category_summaries": category_summaries
     }

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -233,6 +233,50 @@ def should_rank_dashboard_category(scheduled_days):
     return scheduled_days >= DASHBOARD_TOP_CATEGORY_MIN_SCHEDULED_DAYS
 
 
+def select_top_dashboard_habit(habit_summaries):
+    """Pick the top habit using the dashboard's fair ranking rules."""
+    eligible_habits = [
+        habit for habit in habit_summaries
+        if habit["rank_eligible"]
+    ]
+
+    if not eligible_habits:
+        return {
+            "has_data": False,
+            "name": "No top habit yet",
+            "summary": (
+                "Need at least "
+                f"{DASHBOARD_TOP_HABIT_MIN_SCHEDULED_DAYS} scheduled check-ins "
+                "this week to rank habits fairly."
+            ),
+            "detail": "One-off habits do not lead the dashboard."
+        }
+
+    top_habit = sorted(
+        eligible_habits,
+        key=lambda habit: (
+            -habit["weekly_rate"],
+            -habit["current_streak"],
+            -habit["scheduled_days"],
+            -habit["completed_days"],
+            habit["name"].lower()
+        )
+    )[0]
+
+    return {
+        "has_data": True,
+        "name": top_habit["name"],
+        "summary": (
+            f"{top_habit['weekly_rate']}% this week "
+            f"({top_habit['completed_days']}/{top_habit['scheduled_days']})"
+        ),
+        "detail": (
+            f"{top_habit['current_streak']}-day current streak in "
+            f"{top_habit['category']}"
+        )
+    }
+
+
 def classify_dashboard_habit_risk(
     *,
     scheduled_today,
@@ -540,6 +584,7 @@ def build_progress_snapshot(user_id, reference_date=None):
         ),
         "has_scheduled_data": active_days > 0,
         "best_day": best_day,
+        "top_habit": select_top_dashboard_habit(habit_summaries),
         "habit_summaries": habit_summaries,
         "category_summaries": category_summaries
     }

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -127,6 +127,40 @@ def calculate_completion_day_streak(completion_dates, reference_date=None):
     return streak
 
 
+def calculate_longest_habit_streak(
+    schedule_value,
+    created_date,
+    completion_dates,
+    reference_date=None
+):
+    """Track the best scheduled completion streak achieved by one habit."""
+    if reference_date is None:
+        reference_date = date.today()
+
+    if isinstance(created_date, str):
+        created_date = date.fromisoformat(created_date)
+
+    if reference_date < created_date:
+        return 0
+
+    completion_set = set(completion_dates)
+    longest_streak = 0
+    current_streak = 0
+    streak_date = created_date
+
+    while streak_date <= reference_date:
+        if is_habit_scheduled_for_date(schedule_value, streak_date):
+            if streak_date.isoformat() in completion_set:
+                current_streak += 1
+                longest_streak = max(longest_streak, current_streak)
+            else:
+                current_streak = 0
+
+        streak_date += timedelta(days=1)
+
+    return longest_streak
+
+
 def summarize_scheduled_progress(habits, completion_records, target_dates):
     """Average daily completion % across days with scheduled habits only."""
     progress = []
@@ -333,6 +367,184 @@ def get_active_habits_for_user(user_id, target_date):
     ]
 
 
+def build_progress_snapshot(user_id, reference_date=None):
+    """Build one dashboard analytics payload for all future progress widgets."""
+    if reference_date is None:
+        reference_date = date.today()
+
+    today_string = reference_date.isoformat()
+    week_dates = get_trailing_dates(reference_date, DASHBOARD_ANALYTICS_WINDOW_DAYS)
+    previous_week_dates = get_trailing_dates(
+        reference_date,
+        DASHBOARD_ANALYTICS_WINDOW_DAYS,
+        trailing_offset=DASHBOARD_ANALYTICS_WINDOW_DAYS
+    )
+
+    conn = sqlite3.connect("habit_tracker.db")
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        SELECT id, habit_name, category, created_date, schedule
+        FROM habits
+        WHERE user_id = ?
+        ORDER BY habit_name COLLATE NOCASE
+        """,
+        (user_id,)
+    )
+    habit_rows = cursor.fetchall()
+
+    cursor.execute(
+        """
+        SELECT habit_id, completion_date
+        FROM habit_completions
+        WHERE user_id = ?
+        """,
+        (user_id,)
+    )
+    completion_rows = cursor.fetchall()
+    conn.close()
+
+    completion_records = set(completion_rows)
+    completion_days = {completion_date for _, completion_date in completion_rows}
+    completion_map = {}
+    for habit_id, completion_date in completion_rows:
+        completion_map.setdefault(habit_id, set()).add(completion_date)
+
+    progress_habits = [
+        (habit_id, created_date, schedule)
+        for habit_id, _, _, created_date, schedule in habit_rows
+    ]
+
+    weekly_progress, weekly_average, active_days = summarize_scheduled_progress(
+        progress_habits,
+        completion_records,
+        week_dates
+    )
+    _, previous_week_average, previous_active_days = summarize_scheduled_progress(
+        progress_habits,
+        completion_records,
+        previous_week_dates
+    )
+
+    habit_summaries = []
+    category_totals = {}
+
+    for habit_id, habit_name, category, created_date, schedule in habit_rows:
+        completion_dates = completion_map.get(habit_id, set())
+        current_streak = calculate_habit_streak(
+            schedule,
+            created_date,
+            completion_dates,
+            reference_date
+        )
+        best_streak = calculate_longest_habit_streak(
+            schedule,
+            created_date,
+            completion_dates,
+            reference_date
+        )
+
+        scheduled_days = 0
+        completed_days = 0
+        for week_day in week_dates:
+            day_string = week_day.isoformat()
+            if created_date > day_string:
+                continue
+
+            if not is_habit_scheduled_for_date(schedule, week_day):
+                continue
+
+            scheduled_days += 1
+            if (habit_id, day_string) in completion_records:
+                completed_days += 1
+
+        weekly_rate = 0 if scheduled_days == 0 else int(
+            (completed_days / scheduled_days) * 100
+        )
+        scheduled_today = (
+            created_date <= today_string
+            and is_habit_scheduled_for_date(schedule, reference_date)
+        )
+        completed_today = (habit_id, today_string) in completion_records
+        risk_code = None
+        if scheduled_days > 0 or scheduled_today:
+            risk_code = classify_dashboard_habit_risk(
+                scheduled_today=scheduled_today,
+                completed_today=completed_today,
+                weekly_rate=weekly_rate,
+                current_streak=current_streak,
+                best_streak=best_streak
+            )
+
+        habit_category = category or "Uncategorized"
+        habit_summary = {
+            "id": habit_id,
+            "name": habit_name,
+            "category": habit_category,
+            "scheduled_days": scheduled_days,
+            "completed_days": completed_days,
+            "weekly_rate": weekly_rate,
+            "current_streak": current_streak,
+            "best_streak": best_streak,
+            "scheduled_today": scheduled_today,
+            "completed_today": completed_today,
+            "risk_code": risk_code,
+            "rank_eligible": should_rank_dashboard_habit(scheduled_days)
+        }
+        habit_summaries.append(habit_summary)
+
+        category_totals.setdefault(
+            habit_category,
+            {"completed_days": 0, "scheduled_days": 0}
+        )
+        category_totals[habit_category]["completed_days"] += completed_days
+        category_totals[habit_category]["scheduled_days"] += scheduled_days
+
+    category_summaries = []
+    for category_name, totals in sorted(category_totals.items()):
+        scheduled_days = totals["scheduled_days"]
+        completed_days = totals["completed_days"]
+        weekly_rate = 0 if scheduled_days == 0 else int(
+            (completed_days / scheduled_days) * 100
+        )
+        category_summaries.append({
+            "name": category_name,
+            "scheduled_days": scheduled_days,
+            "completed_days": completed_days,
+            "weekly_rate": weekly_rate,
+            "rank_eligible": should_rank_dashboard_category(scheduled_days)
+        })
+
+    best_day = {"label": "No data", "completed": 0, "goal": 0}
+    if weekly_progress:
+        best_day = max(
+            weekly_progress,
+            key=lambda item: (item["percentage"], item["completed"])
+        )
+
+    return {
+        "reference_date": today_string,
+        "weekly_progress": weekly_progress,
+        "weekly_average": weekly_average,
+        "previous_week_average": previous_week_average,
+        "weekly_change_summary": summarize_week_over_week_change(
+            weekly_average,
+            previous_week_average,
+            active_days,
+            previous_active_days
+        ),
+        "current_streak": calculate_completion_day_streak(
+            completion_days,
+            reference_date
+        ),
+        "has_scheduled_data": active_days > 0,
+        "best_day": best_day,
+        "habit_summaries": habit_summaries,
+        "category_summaries": category_summaries
+    }
+
+
 def init_db():
     conn = sqlite3.connect("habit_tracker.db")
     cursor = conn.cursor()
@@ -472,6 +684,7 @@ def dashboard():
 
     today_date = date.today()
     today = today_date.isoformat()
+    progress_snapshot = build_progress_snapshot(session["user_id"], today_date)
 
     quotes = [
         "Small progress is still progress.",
@@ -544,7 +757,8 @@ def dashboard():
         health_profile=health_profile,
         bmi=bmi,
         today_steps=today_steps,
-        today_videos=today_videos
+        today_videos=today_videos,
+        progress_snapshot=progress_snapshot
     )
 
 

--- a/Habit-tracker/app.py
+++ b/Habit-tracker/app.py
@@ -235,19 +235,19 @@ def summarize_week_over_week_change(
 ):
     """Describe weekly movement using the same scheduled-day completion rule."""
     if current_active_days == 0:
-        return "No scheduled habits this week yet."
+        return "No scheduled check-ins yet this week."
 
     if previous_active_days == 0:
-        return "First active week with scheduled habit data."
+        return "This is the first week with enough scheduled data to compare."
 
     delta = current_average - previous_average
     if delta > 0:
-        return f"{delta} percentage points better than last week"
+        return f"Up {delta} points from last week"
 
     if delta < 0:
-        return f"{abs(delta)} percentage points behind last week"
+        return f"Down {abs(delta)} points from last week"
 
-    return "Matching last week"
+    return "Steady with last week"
 
 
 def should_rank_dashboard_habit(scheduled_days):
@@ -270,13 +270,13 @@ def select_top_dashboard_habit(habit_summaries):
     if not eligible_habits:
         return {
             "has_data": False,
-            "name": "No top habit yet",
+            "name": "Ranking unlocks soon",
             "summary": (
-                "Need at least "
+                "Habits need at least "
                 f"{DASHBOARD_TOP_HABIT_MIN_SCHEDULED_DAYS} scheduled check-ins "
-                "this week to rank habits fairly."
+                "this week before this card can rank them fairly."
             ),
-            "detail": "One-off habits do not lead the dashboard."
+            "detail": "Once a habit has a fuller week, the leader will appear here."
         }
 
     top_habit = sorted(
@@ -321,8 +321,8 @@ def summarize_dashboard_risk(habit_summaries):
     if total_flagged == 0:
         return {
             "count": 0,
-            "summary": "No habits flagged",
-            "detail": "Nothing is currently due, below pace, or cooling off."
+            "summary": "Everything is on track",
+            "detail": "Nothing is due, behind pace, or losing momentum right now."
         }
 
     if risk_counts["due_today"] > 0:

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -331,7 +331,7 @@ h1, h2, h3, h4, h5 {
 
 .summary-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
     gap: 18px;
     margin-bottom: 22px;
 }
@@ -369,6 +369,11 @@ h1, h2, h3, h4, h5 {
 
 .summary-card.orange .summary-icon {
     background: #ffedd5;
+}
+
+.summary-card.red .summary-icon {
+    background: #fee2e2;
+    color: #b91c1c;
 }
 
 .weekly-insight-card {

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -566,6 +566,87 @@ h1, h2, h3, h4, h5 {
     color: #64748b;
 }
 
+.focus-panel-card {
+    background: rgba(255,255,255,0.97);
+    border-radius: 28px;
+    padding: 28px 30px;
+    margin-bottom: 22px;
+    box-shadow: 0 18px 36px rgba(15,23,42,0.08);
+}
+
+.focus-panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 18px;
+    margin-bottom: 20px;
+}
+
+.focus-panel-header h3 {
+    margin-bottom: 8px;
+}
+
+.focus-panel-header p {
+    color: #64748b;
+    max-width: 560px;
+}
+
+.focus-panel-count {
+    background: #fee2e2;
+    color: #b91c1c;
+    border-radius: 999px;
+    padding: 9px 13px;
+    font-size: 13px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.focus-panel-list {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.focus-panel-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 18px;
+    padding: 18px 20px;
+    border-radius: 22px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+}
+
+.focus-panel-reason {
+    display: inline-block;
+    margin-bottom: 10px;
+    background: #dbeafe;
+    color: #1d4ed8;
+    border-radius: 999px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.focus-panel-item h4,
+.focus-panel-empty h4 {
+    margin: 0 0 6px;
+    font-size: 19px;
+}
+
+.focus-panel-item p,
+.focus-panel-empty p {
+    color: #64748b;
+}
+
+.focus-panel-empty {
+    border-radius: 22px;
+    background: linear-gradient(135deg, #ecfeff, #f0fdf4);
+    border: 1px solid #bbf7d0;
+    padding: 24px;
+}
+
 /* Cards */
 
 .dash-card {
@@ -967,6 +1048,12 @@ h1, h2, h3, h4, h5 {
     }
 
     .weekly-trend-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .focus-panel-header,
+    .focus-panel-item {
         flex-direction: column;
         align-items: flex-start;
     }

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -331,9 +331,9 @@ h1, h2, h3, h4, h5 {
 
 .summary-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 18px;
-    margin-bottom: 22px;
+    margin-bottom: 18px;
 }
 
 .summary-card {
@@ -371,89 +371,76 @@ h1, h2, h3, h4, h5 {
     background: #ffedd5;
 }
 
-.summary-card.red .summary-icon {
-    background: #fee2e2;
-    color: #b91c1c;
+.summary-card-stacked {
+    align-items: flex-start;
 }
 
-.weekly-insight-card {
-    background: linear-gradient(135deg, rgba(37,99,235,0.96), rgba(29,78,216,0.90));
-    color: white;
-    border-radius: 28px;
-    padding: 28px 30px;
-    margin-bottom: 22px;
-    display: grid;
-    grid-template-columns: 1.25fr 0.75fr 0.7fr;
-    gap: 22px;
-    align-items: center;
-    box-shadow: 0 20px 44px rgba(37,99,235,0.20);
+.summary-card-stacked span {
+    display: block;
+    color: #475569;
+    font-size: 13px;
+    line-height: 1.45;
 }
 
-.weekly-insight-copy h2 {
+.split-card .summary-icon {
+    background: #dcfce7;
+}
+
+.split-card-content {
+    width: 100%;
+}
+
+.split-card-title {
     margin-bottom: 10px;
 }
 
-.weekly-insight-copy p {
-    margin-bottom: 0;
-    color: rgba(255,255,255,0.82);
-    max-width: 520px;
+.split-card-metrics {
+    display: flex;
+    margin-bottom: 8px;
 }
 
-.weekly-insight-metric,
-.weekly-insight-detail,
-.weekly-insight-empty {
-    background: rgba(255,255,255,0.14);
-    border: 1px solid rgba(255,255,255,0.18);
-    border-radius: 22px;
-    padding: 20px 22px;
+.split-card-metric {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
 }
 
-.weekly-insight-label,
-.weekly-insight-detail-label {
+.split-card-label {
     display: block;
     margin-bottom: 8px;
     font-size: 12px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     font-weight: 700;
-    color: rgba(255,255,255,0.72);
+    color: #64748b;
 }
 
-.weekly-insight-metric h3 {
-    font-size: 40px;
-    margin-bottom: 8px;
-}
-
-.weekly-insight-trend {
-    color: white;
-    font-weight: 700;
-}
-
-.weekly-insight-detail strong,
-.weekly-insight-empty strong {
+.split-card-metric strong {
     display: block;
-    font-size: 24px;
-    margin-bottom: 6px;
+    font-size: 30px;
+    line-height: 1;
+    color: #0f172a;
 }
 
-.weekly-insight-detail span,
-.weekly-insight-empty span {
-    color: rgba(255,255,255,0.82);
-}
-
-.weekly-insight-note {
+.split-card-detail {
     display: block;
-    margin-top: 10px;
-    font-size: 14px;
-    color: rgba(255,255,255,0.70);
+    color: #475569;
+    font-size: 13px;
+}
+
+.analytics-grid {
+    display: grid;
+    grid-template-columns: 1.45fr 1fr;
+    gap: 18px;
+    margin-bottom: 22px;
 }
 
 .weekly-trend-card {
     background: rgba(255,255,255,0.97);
     border-radius: 28px;
     padding: 28px 30px;
-    margin-bottom: 22px;
     box-shadow: 0 18px 36px rgba(15,23,42,0.08);
+    height: 100%;
 }
 
 .weekly-trend-header {
@@ -549,6 +536,12 @@ h1, h2, h3, h4, h5 {
     color: #64748b;
 }
 
+.weekly-bar-group.future .weekly-bar-percent,
+.weekly-bar-group.future .weekly-bar-value,
+.weekly-bar-group.future .weekly-bar-label {
+    color: #94a3b8;
+}
+
 .weekly-trend-empty {
     border-radius: 22px;
     background: linear-gradient(135deg, #eff6ff, #f8fafc);
@@ -570,8 +563,8 @@ h1, h2, h3, h4, h5 {
     background: rgba(255,255,255,0.97);
     border-radius: 28px;
     padding: 28px 30px;
-    margin-bottom: 22px;
     box-shadow: 0 18px 36px rgba(15,23,42,0.08);
+    height: 100%;
 }
 
 .focus-panel-header {
@@ -591,14 +584,33 @@ h1, h2, h3, h4, h5 {
     max-width: 560px;
 }
 
-.focus-panel-count {
-    background: #fee2e2;
-    color: #b91c1c;
-    border-radius: 999px;
-    padding: 9px 13px;
-    font-size: 13px;
+.focus-panel-highlight {
+    background: #f5f3ff;
+    border: 1px solid #ddd6fe;
+    border-radius: 18px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+}
+
+.focus-panel-highlight-label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
     font-weight: 700;
-    white-space: nowrap;
+    color: #7c3aed;
+}
+
+.focus-panel-highlight strong {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 20px;
+    color: #0f172a;
+}
+
+.focus-panel-highlight small {
+    color: #64748b;
 }
 
 .focus-panel-list {
@@ -645,6 +657,35 @@ h1, h2, h3, h4, h5 {
     background: linear-gradient(135deg, #ecfeff, #f0fdf4);
     border: 1px solid #bbf7d0;
     padding: 24px;
+}
+
+.today-snapshot-list {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+    margin: 16px 0 18px;
+}
+
+.today-snapshot-item {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    padding: 14px 16px;
+}
+
+.today-snapshot-item span {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+    font-weight: 700;
+}
+
+.today-snapshot-item strong {
+    font-size: 24px;
+    color: #0f172a;
 }
 
 /* Cards */
@@ -1039,11 +1080,9 @@ h1, h2, h3, h4, h5 {
 
 @media (max-width: 1000px) {
     .summary-grid,
-    .dashboard-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .weekly-insight-card {
+    .analytics-grid,
+    .dashboard-grid,
+    .today-snapshot-list {
         grid-template-columns: 1fr;
     }
 

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -311,6 +311,9 @@ h1, h2, h3, h4, h5 {
     margin-left: 270px;
     width: calc(100% - 270px);
     padding: 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
 }
 
 .dashboard-top {
@@ -318,7 +321,7 @@ h1, h2, h3, h4, h5 {
     justify-content: space-between;
     align-items: center;
     gap: 20px;
-    margin-bottom: 24px;
+    margin-bottom: 0;
 }
 
 .dashboard-top h1 {
@@ -333,7 +336,7 @@ h1, h2, h3, h4, h5 {
 
 .date-pill {
     background: rgba(255,255,255,0.96);
-    padding: 14px 20px;
+    padding: 12px 18px;
     border-radius: 18px;
     box-shadow: 0 10px 28px rgba(15,23,42,0.08);
     color: #334155;
@@ -346,19 +349,19 @@ h1, h2, h3, h4, h5 {
 .summary-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 18px;
-    margin-bottom: 18px;
+    gap: 16px;
+    margin-bottom: 0;
 }
 
 .summary-card {
     background: rgba(255,255,255,0.96);
-    border-radius: 22px;
-    padding: 24px;
+    border-radius: 20px;
+    padding: 20px 22px;
     display: flex;
-    gap: 18px;
+    gap: 16px;
     align-items: center;
-    min-height: 156px;
-    box-shadow: 0 14px 30px rgba(15,23,42,0.07);
+    min-height: 144px;
+    box-shadow: 0 10px 24px rgba(15,23,42,0.06);
     border: 1px solid rgba(226,232,240,0.9);
 }
 
@@ -369,14 +372,24 @@ h1, h2, h3, h4, h5 {
     color: #0f172a;
 }
 
+.summary-card p {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
 .summary-icon {
-    width: 58px;
-    height: 58px;
-    border-radius: 16px;
+    width: 52px;
+    height: 52px;
+    border-radius: 14px;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 28px;
+    font-size: 24px;
+    flex-shrink: 0;
 }
 
 .summary-card.purple .summary-icon {
@@ -403,13 +416,14 @@ h1, h2, h3, h4, h5 {
     display: block;
     color: #475569;
     font-size: 13px;
-    line-height: 1.45;
+    line-height: 1.55;
 }
 
 .summary-card-stacked h2,
 .summary-card h2 {
-    margin: 6px 0 10px;
+    margin: 8px 0 8px;
     line-height: 1;
+    font-size: 34px;
 }
 
 .split-card .summary-icon {
@@ -421,12 +435,12 @@ h1, h2, h3, h4, h5 {
 }
 
 .split-card-title {
-    margin-bottom: 10px;
+    margin-bottom: 8px;
 }
 
 .split-card-metrics {
     display: flex;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
 }
 
 .split-card-metric {
@@ -462,16 +476,22 @@ h1, h2, h3, h4, h5 {
 .analytics-grid {
     display: grid;
     grid-template-columns: 1.45fr 1fr;
-    gap: 18px;
-    margin-bottom: 22px;
+    gap: 16px;
+    margin-bottom: 0;
+    align-items: stretch;
+}
+
+.analytics-primary-column {
+    display: grid;
+    gap: 16px;
+    align-content: start;
 }
 
 .weekly-trend-card {
     background: rgba(255,255,255,0.97);
-    border-radius: 28px;
-    padding: 28px 30px;
-    box-shadow: 0 18px 36px rgba(15,23,42,0.08);
-    height: 100%;
+    border-radius: 24px;
+    padding: 24px 26px;
+    box-shadow: 0 14px 30px rgba(15,23,42,0.07);
     border: 1px solid rgba(226,232,240,0.9);
 }
 
@@ -480,7 +500,7 @@ h1, h2, h3, h4, h5 {
     justify-content: space-between;
     align-items: flex-start;
     gap: 20px;
-    margin-bottom: 22px;
+    margin-bottom: 18px;
 }
 
 .weekly-trend-header h3 {
@@ -489,15 +509,16 @@ h1, h2, h3, h4, h5 {
 
 .weekly-trend-header p {
     color: #64748b;
-    max-width: 580px;
+    max-width: 520px;
+    line-height: 1.5;
 }
 
 .weekly-trend-badge {
     min-width: 150px;
     background: #eff6ff;
     border: 1px solid #bfdbfe;
-    border-radius: 20px;
-    padding: 14px 16px;
+    border-radius: 18px;
+    padding: 12px 14px;
     text-align: right;
 }
 
@@ -510,16 +531,16 @@ h1, h2, h3, h4, h5 {
 .weekly-trend-badge strong {
     display: block;
     margin: 4px 0;
-    font-size: 22px;
+    font-size: 20px;
     color: #0f172a;
 }
 
 .weekly-bars {
     display: grid;
     grid-template-columns: repeat(7, minmax(0, 1fr));
-    gap: 14px;
+    gap: 12px;
     align-items: end;
-    min-height: 308px;
+    min-height: 274px;
 }
 
 .weekly-bar-group {
@@ -528,10 +549,10 @@ h1, h2, h3, h4, h5 {
 }
 
 .weekly-bar-track {
-    height: 220px;
-    border-radius: 20px;
+    height: 200px;
+    border-radius: 18px;
     background: linear-gradient(180deg, #e2e8f0 0%, #f8fafc 100%);
-    padding: 10px;
+    padding: 9px;
     display: flex;
     align-items: flex-end;
 }
@@ -554,7 +575,7 @@ h1, h2, h3, h4, h5 {
 }
 
 .weekly-bar-percent {
-    margin: 10px 0 2px;
+    margin: 8px 0 2px;
     font-weight: 800;
     color: #1d4ed8;
 }
@@ -577,10 +598,10 @@ h1, h2, h3, h4, h5 {
 }
 
 .weekly-trend-empty {
-    border-radius: 22px;
+    border-radius: 20px;
     background: linear-gradient(135deg, #eff6ff, #f8fafc);
     border: 1px solid #bfdbfe;
-    padding: 24px;
+    padding: 22px;
 }
 
 .weekly-trend-empty strong {
@@ -595,11 +616,13 @@ h1, h2, h3, h4, h5 {
 
 .focus-panel-card {
     background: rgba(255,255,255,0.97);
-    border-radius: 28px;
-    padding: 28px 30px;
-    box-shadow: 0 18px 36px rgba(15,23,42,0.08);
-    height: 100%;
+    border-radius: 24px;
+    padding: 24px 26px;
+    box-shadow: 0 14px 30px rgba(15,23,42,0.07);
     border: 1px solid rgba(226,232,240,0.9);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .focus-panel-header {
@@ -607,7 +630,7 @@ h1, h2, h3, h4, h5 {
     justify-content: space-between;
     align-items: flex-start;
     gap: 18px;
-    margin-bottom: 20px;
+    margin-bottom: 16px;
 }
 
 .focus-panel-header h3 {
@@ -617,14 +640,15 @@ h1, h2, h3, h4, h5 {
 .focus-panel-header p {
     color: #64748b;
     max-width: 560px;
+    line-height: 1.5;
 }
 
 .focus-panel-highlight {
     background: #f5f3ff;
     border: 1px solid #ddd6fe;
-    border-radius: 18px;
+    border-radius: 16px;
     padding: 14px 16px;
-    margin-bottom: 16px;
+    margin-bottom: 14px;
 }
 
 .focus-panel-highlight-label {
@@ -651,7 +675,45 @@ h1, h2, h3, h4, h5 {
 .focus-panel-list {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 12px;
+    flex: 1;
+}
+
+.focus-panel-placeholder {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    border-radius: 18px;
+    padding: 20px 22px;
+    background: linear-gradient(135deg, #f8fafc, #eef6ff);
+    border: 1px dashed #cbd5e1;
+}
+
+.focus-panel-placeholder-label {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    margin-bottom: 10px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: white;
+    color: #475569;
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.focus-panel-placeholder h4 {
+    margin: 0 0 8px;
+    font-size: 20px;
+    color: #0f172a;
+}
+
+.focus-panel-placeholder p {
+    color: #64748b;
+    line-height: 1.6;
 }
 
 .focus-panel-item {
@@ -659,8 +721,8 @@ h1, h2, h3, h4, h5 {
     justify-content: space-between;
     align-items: center;
     gap: 18px;
-    padding: 18px 20px;
-    border-radius: 22px;
+    padding: 16px 18px;
+    border-radius: 18px;
     background: #f8fafc;
     border: 1px solid #e2e8f0;
 }
@@ -692,56 +754,163 @@ h1, h2, h3, h4, h5 {
 }
 
 .focus-panel-empty {
-    border-radius: 22px;
+    border-radius: 18px;
     background: linear-gradient(135deg, #ecfeff, #f0fdf4);
     border: 1px solid #bbf7d0;
-    padding: 24px;
-}
-
-.today-snapshot-list {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 12px;
-    margin: 16px 0 18px;
-}
-
-.today-snapshot-item {
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 18px;
-    padding: 14px 16px;
-}
-
-.today-snapshot-item span {
-    display: block;
-    margin-bottom: 8px;
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: #64748b;
-    font-weight: 700;
-}
-
-.today-snapshot-item strong {
-    font-size: 24px;
-    color: #0f172a;
+    padding: 22px;
+    flex: 1;
 }
 
 /* Cards */
 
 .dash-card {
     background: rgba(255,255,255,0.97);
-    border-radius: 24px;
-    padding: 26px;
-    box-shadow: 0 14px 30px rgba(0,0,0,0.06);
+    border-radius: 22px;
+    padding: 22px 24px;
+    box-shadow: 0 12px 26px rgba(15,23,42,0.06);
     border: 1px solid rgba(226,232,240,0.9);
 }
 
 .dashboard-grid {
     display: grid;
-    grid-template-columns: 1fr 1.5fr 1.1fr;
-    gap: 18px;
+    grid-template-columns: 1.55fr 0.9fr;
+    gap: 16px;
     align-items: start;
+}
+
+.streak-card {
+    background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(248,250,252,0.98));
+}
+
+.streak-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.streak-card-header p {
+    color: #64748b;
+    line-height: 1.5;
+}
+
+.streak-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #2563eb, #22c55e);
+    color: white;
+    border-radius: 999px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.streak-progress-block {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    padding: 16px;
+    margin-bottom: 12px;
+}
+
+.streak-progress-label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 800;
+    color: #64748b;
+}
+
+.streak-progress-topline {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.streak-progress-topline strong {
+    font-size: 28px;
+    line-height: 1;
+    color: #0f172a;
+}
+
+.streak-progress-topline span,
+.streak-progress-scale,
+.streak-note-card span,
+.streak-note-card small,
+.streak-card-detail {
+    color: #64748b;
+}
+
+.streak-progress-track {
+    width: 100%;
+    height: 14px;
+    border-radius: 999px;
+    background: #dbe7f5;
+    overflow: hidden;
+}
+
+.streak-progress-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #2563eb 0%, #14b8a6 55%, #22c55e 100%);
+    box-shadow: 0 8px 18px rgba(37,99,235,0.18);
+}
+
+.streak-progress-scale {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.streak-card-notes {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.streak-note-card {
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
+    padding: 14px 15px;
+}
+
+.streak-note-card span {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+}
+
+.streak-note-card strong {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 22px;
+    line-height: 1.1;
+    color: #0f172a;
+}
+
+.streak-note-card small {
+    display: block;
+    line-height: 1.45;
+}
+
+.streak-card-detail {
+    line-height: 1.6;
 }
 
 /* Health */
@@ -761,10 +930,10 @@ h1, h2, h3, h4, h5 {
 /* Steps */
 
 .steps-ring {
-    width: 210px;
-    height: 210px;
+    width: 190px;
+    height: 190px;
     border-radius: 50%;
-    margin: 25px auto;
+    margin: 20px auto;
     background: conic-gradient(
         #22c55e 0% 70%,
         #e5e7eb 70% 100%
@@ -775,8 +944,8 @@ h1, h2, h3, h4, h5 {
 }
 
 .steps-ring > div {
-    width: 155px;
-    height: 155px;
+    width: 142px;
+    height: 142px;
     border-radius: 50%;
     background: white;
     display: flex;
@@ -786,7 +955,7 @@ h1, h2, h3, h4, h5 {
 }
 
 .steps-ring h2 {
-    font-size: 40px;
+    font-size: 36px;
     font-weight: 900;
     margin: 0;
 }
@@ -795,7 +964,7 @@ h1, h2, h3, h4, h5 {
 
 .video-thumbnail {
     width: 100%;
-    height: 210px;
+    height: 196px;
     object-fit: cover;
     border-radius: 14px;
     transition: 0.3s;
@@ -1120,6 +1289,19 @@ h1, h2, h3, h4, h5 {
     overflow: hidden;
 }
 
+.analytics-grid .dash-card,
+.analytics-grid > div {
+    min-width: 0;
+}
+
+.dashboard-main > .dash-card.mt-4 {
+    margin-top: 0 !important;
+}
+
+.dashboard-grid > .dash-card:last-child {
+    align-self: start;
+}
+
 @media (max-width: 1280px) {
     .dashboard-main {
         padding: 30px;
@@ -1154,6 +1336,14 @@ h1, h2, h3, h4, h5 {
     .dashboard-grid,
     .today-snapshot-list {
         grid-template-columns: 1fr;
+    }
+
+    .analytics-primary-column {
+        gap: 14px;
+    }
+
+    .dashboard-main {
+        gap: 16px;
     }
 
     .weekly-trend-header {
@@ -1937,6 +2127,7 @@ h1, h2, h3, h4, h5 {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 14px;
+    margin-bottom: 16px;
 }
 
 .health-metric {

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -371,6 +371,71 @@ h1, h2, h3, h4, h5 {
     background: #ffedd5;
 }
 
+.weekly-insight-card {
+    background: linear-gradient(135deg, rgba(37,99,235,0.96), rgba(29,78,216,0.90));
+    color: white;
+    border-radius: 28px;
+    padding: 28px 30px;
+    margin-bottom: 22px;
+    display: grid;
+    grid-template-columns: 1.25fr 0.75fr 0.7fr;
+    gap: 22px;
+    align-items: center;
+    box-shadow: 0 20px 44px rgba(37,99,235,0.20);
+}
+
+.weekly-insight-copy h2 {
+    margin-bottom: 10px;
+}
+
+.weekly-insight-copy p {
+    margin-bottom: 0;
+    color: rgba(255,255,255,0.82);
+    max-width: 520px;
+}
+
+.weekly-insight-metric,
+.weekly-insight-detail,
+.weekly-insight-empty {
+    background: rgba(255,255,255,0.14);
+    border: 1px solid rgba(255,255,255,0.18);
+    border-radius: 22px;
+    padding: 20px 22px;
+}
+
+.weekly-insight-label,
+.weekly-insight-detail-label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: rgba(255,255,255,0.72);
+}
+
+.weekly-insight-metric h3 {
+    font-size: 40px;
+    margin-bottom: 8px;
+}
+
+.weekly-insight-trend {
+    color: white;
+    font-weight: 700;
+}
+
+.weekly-insight-detail strong,
+.weekly-insight-empty strong {
+    display: block;
+    font-size: 24px;
+    margin-bottom: 6px;
+}
+
+.weekly-insight-detail span,
+.weekly-insight-empty span {
+    color: rgba(255,255,255,0.82);
+}
+
 /* Cards */
 
 .dash-card {
@@ -764,6 +829,10 @@ h1, h2, h3, h4, h5 {
 @media (max-width: 1000px) {
     .summary-grid,
     .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .weekly-insight-card {
         grid-template-columns: 1fr;
     }
 

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -448,6 +448,124 @@ h1, h2, h3, h4, h5 {
     color: rgba(255,255,255,0.70);
 }
 
+.weekly-trend-card {
+    background: rgba(255,255,255,0.97);
+    border-radius: 28px;
+    padding: 28px 30px;
+    margin-bottom: 22px;
+    box-shadow: 0 18px 36px rgba(15,23,42,0.08);
+}
+
+.weekly-trend-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 20px;
+    margin-bottom: 22px;
+}
+
+.weekly-trend-header h3 {
+    margin-bottom: 8px;
+}
+
+.weekly-trend-header p {
+    color: #64748b;
+    max-width: 580px;
+}
+
+.weekly-trend-badge {
+    min-width: 150px;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    border-radius: 20px;
+    padding: 14px 16px;
+    text-align: right;
+}
+
+.weekly-trend-badge span,
+.weekly-trend-badge small {
+    display: block;
+    color: #64748b;
+}
+
+.weekly-trend-badge strong {
+    display: block;
+    margin: 4px 0;
+    font-size: 22px;
+    color: #0f172a;
+}
+
+.weekly-bars {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 14px;
+    align-items: end;
+}
+
+.weekly-bar-group {
+    text-align: center;
+}
+
+.weekly-bar-track {
+    height: 220px;
+    border-radius: 20px;
+    background: linear-gradient(180deg, #e2e8f0 0%, #f8fafc 100%);
+    padding: 10px;
+    display: flex;
+    align-items: flex-end;
+}
+
+.weekly-bar-fill {
+    width: 100%;
+    border-radius: 14px;
+    background: linear-gradient(180deg, #2563eb 0%, #22c55e 100%);
+    box-shadow: 0 10px 24px rgba(37,99,235,0.20);
+}
+
+.weekly-bar-fill.zero {
+    background: linear-gradient(180deg, #f59e0b 0%, #f97316 100%);
+    box-shadow: none;
+}
+
+.weekly-bar-fill.empty {
+    background: transparent;
+    box-shadow: none;
+}
+
+.weekly-bar-percent {
+    margin: 10px 0 2px;
+    font-weight: 800;
+    color: #1d4ed8;
+}
+
+.weekly-bar-value {
+    margin: 0 0 4px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.weekly-bar-label {
+    font-size: 13px;
+    color: #64748b;
+}
+
+.weekly-trend-empty {
+    border-radius: 22px;
+    background: linear-gradient(135deg, #eff6ff, #f8fafc);
+    border: 1px solid #bfdbfe;
+    padding: 24px;
+}
+
+.weekly-trend-empty strong {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 22px;
+}
+
+.weekly-trend-empty span {
+    color: #64748b;
+}
+
 /* Cards */
 
 .dash-card {
@@ -846,6 +964,19 @@ h1, h2, h3, h4, h5 {
 
     .weekly-insight-card {
         grid-template-columns: 1fr;
+    }
+
+    .weekly-trend-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .weekly-bars {
+        gap: 10px;
+    }
+
+    .weekly-bar-track {
+        height: 180px;
     }
 
     .dashboard-layout {

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -310,21 +310,35 @@ h1, h2, h3, h4, h5 {
 .dashboard-main {
     margin-left: 270px;
     width: calc(100% - 270px);
-    padding: 40px;
+    padding: 36px;
 }
 
 .dashboard-top {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 28px;
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.dashboard-top h1 {
+    margin-bottom: 8px;
+}
+
+.dashboard-top p {
+    margin: 0;
+    max-width: 640px;
+    color: #475569;
 }
 
 .date-pill {
-    background: white;
+    background: rgba(255,255,255,0.96);
     padding: 14px 20px;
-    border-radius: 16px;
-    box-shadow: 0 8px 20px rgba(0,0,0,0.05);
+    border-radius: 18px;
+    box-shadow: 0 10px 28px rgba(15,23,42,0.08);
+    color: #334155;
+    font-weight: 600;
+    max-width: 340px;
 }
 
 /* Summary */
@@ -343,6 +357,16 @@ h1, h2, h3, h4, h5 {
     display: flex;
     gap: 18px;
     align-items: center;
+    min-height: 156px;
+    box-shadow: 0 14px 30px rgba(15,23,42,0.07);
+    border: 1px solid rgba(226,232,240,0.9);
+}
+
+.summary-card p,
+.dash-card h3,
+.weekly-trend-header h3,
+.focus-panel-header h3 {
+    color: #0f172a;
 }
 
 .summary-icon {
@@ -380,6 +404,12 @@ h1, h2, h3, h4, h5 {
     color: #475569;
     font-size: 13px;
     line-height: 1.45;
+}
+
+.summary-card-stacked h2,
+.summary-card h2 {
+    margin: 6px 0 10px;
+    line-height: 1;
 }
 
 .split-card .summary-icon {
@@ -426,6 +456,7 @@ h1, h2, h3, h4, h5 {
     display: block;
     color: #475569;
     font-size: 13px;
+    line-height: 1.5;
 }
 
 .analytics-grid {
@@ -441,6 +472,7 @@ h1, h2, h3, h4, h5 {
     padding: 28px 30px;
     box-shadow: 0 18px 36px rgba(15,23,42,0.08);
     height: 100%;
+    border: 1px solid rgba(226,232,240,0.9);
 }
 
 .weekly-trend-header {
@@ -487,10 +519,12 @@ h1, h2, h3, h4, h5 {
     grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 14px;
     align-items: end;
+    min-height: 308px;
 }
 
 .weekly-bar-group {
     text-align: center;
+    min-width: 0;
 }
 
 .weekly-bar-track {
@@ -565,6 +599,7 @@ h1, h2, h3, h4, h5 {
     padding: 28px 30px;
     box-shadow: 0 18px 36px rgba(15,23,42,0.08);
     height: 100%;
+    border: 1px solid rgba(226,232,240,0.9);
 }
 
 .focus-panel-header {
@@ -628,6 +663,10 @@ h1, h2, h3, h4, h5 {
     border-radius: 22px;
     background: #f8fafc;
     border: 1px solid #e2e8f0;
+}
+
+.focus-panel-item .btn {
+    flex-shrink: 0;
 }
 
 .focus-panel-reason {
@@ -695,12 +734,14 @@ h1, h2, h3, h4, h5 {
     border-radius: 24px;
     padding: 26px;
     box-shadow: 0 14px 30px rgba(0,0,0,0.06);
+    border: 1px solid rgba(226,232,240,0.9);
 }
 
 .dashboard-grid {
     display: grid;
     grid-template-columns: 1fr 1.5fr 1.1fr;
     gap: 18px;
+    align-items: start;
 }
 
 /* Health */
@@ -1074,11 +1115,40 @@ h1, h2, h3, h4, h5 {
     color: #991b1b;
 }
 
+.dashboard-grid .dash-card,
+.analytics-grid > section {
+    overflow: hidden;
+}
+
+@media (max-width: 1280px) {
+    .dashboard-main {
+        padding: 30px;
+    }
+
+    .dashboard-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .health-profile-card {
+        grid-column: span 2;
+    }
+}
+
 /* =======================================================
    MOBILE
 ======================================================= */
 
 @media (max-width: 1000px) {
+    .dashboard-top {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .date-pill {
+        max-width: none;
+        width: 100%;
+    }
+
     .summary-grid,
     .analytics-grid,
     .dashboard-grid,
@@ -1095,6 +1165,10 @@ h1, h2, h3, h4, h5 {
     .focus-panel-item {
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    .focus-panel-item .btn {
+        width: 100%;
     }
 
     .weekly-bars {
@@ -1122,6 +1196,10 @@ h1, h2, h3, h4, h5 {
         padding: 20px;
     }
 
+    .summary-card {
+        min-height: auto;
+    }
+
     .habit-item {
         flex-direction: column;
         align-items: flex-start;
@@ -1137,6 +1215,68 @@ h1, h2, h3, h4, h5 {
     .calendar-date-form {
         width: 100%;
         align-items: flex-start;
+    }
+}
+
+@media (max-width: 768px) {
+    .dashboard-main {
+        padding: 16px;
+    }
+
+    .summary-card,
+    .weekly-trend-card,
+    .focus-panel-card,
+    .dash-card {
+        padding: 22px;
+        border-radius: 22px;
+    }
+
+    .health-profile-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .steps-ring {
+        width: 180px;
+        height: 180px;
+    }
+
+    .steps-ring > div {
+        width: 132px;
+        height: 132px;
+    }
+
+    .steps-ring h2 {
+        font-size: 34px;
+    }
+}
+
+@media (max-width: 640px) {
+    .dashboard-top h1 {
+        font-size: 32px;
+    }
+
+    .weekly-trend-badge {
+        width: 100%;
+        text-align: left;
+    }
+
+    .health-profile-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .active-preview-header {
+        flex-direction: column;
+        align-items: flex-start !important;
+        gap: 14px;
+    }
+
+    .active-preview-actions {
+        width: 100%;
+        flex-direction: column;
+    }
+
+    .active-preview-actions .btn {
+        width: 100%;
     }
 }
 

--- a/Habit-tracker/static/style.css
+++ b/Habit-tracker/static/style.css
@@ -436,6 +436,13 @@ h1, h2, h3, h4, h5 {
     color: rgba(255,255,255,0.82);
 }
 
+.weekly-insight-note {
+    display: block;
+    margin-top: 10px;
+    font-size: 14px;
+    color: rgba(255,255,255,0.70);
+}
+
 /* Cards */
 
 .dash-card {

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -126,6 +126,56 @@
             {% endif %}
         </section>
 
+        <section class="weekly-trend-card">
+            <div class="weekly-trend-header">
+                <div>
+                    <h3>Weekly trend</h3>
+                    <p class="mb-0">
+                        A 7-day view of completed habits versus the habits that were
+                        scheduled each day this week.
+                    </p>
+                </div>
+
+                {% if progress_snapshot.has_scheduled_data and progress_snapshot.best_day.goal > 0 %}
+                    <div class="weekly-trend-badge">
+                        <span>Best day</span>
+                        <strong>{{ progress_snapshot.best_day.label }}</strong>
+                        <small>
+                            {{ progress_snapshot.best_day.completed }}/{{ progress_snapshot.best_day.goal }}
+                            completed
+                        </small>
+                    </div>
+                {% endif %}
+            </div>
+
+            {% if progress_snapshot.has_scheduled_data %}
+                <div class="weekly-bars">
+                    {% for day in progress_snapshot.weekly_progress %}
+                        <div class="weekly-bar-group">
+                            <div class="weekly-bar-track">
+                                <div
+                                    class="weekly-bar-fill {% if day.goal == 0 %}empty{% elif day.percentage == 0 %}zero{% endif %}"
+                                    style="height: {% if day.goal == 0 %}0{% elif day.percentage == 0 %}12px{% else %}{{ day.percentage }}%{% endif %};"
+                                    title="{{ day.percentage }}% ({{ day.completed }}/{{ day.goal }})"
+                                ></div>
+                            </div>
+                            <p class="weekly-bar-percent">{{ day.percentage }}%</p>
+                            <p class="weekly-bar-value">{{ day.completed }}/{{ day.goal }}</p>
+                            <p class="weekly-bar-label mb-0">{{ day.label }}</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="weekly-trend-empty">
+                    <strong>No weekly trend yet</strong>
+                    <span>
+                        Once your habits have scheduled check-ins, this chart will
+                        start showing how each day is tracking.
+                    </span>
+                </div>
+            {% endif %}
+        </section>
+
         <div class="dashboard-grid">
 
             <section class="dash-card">

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -99,16 +99,14 @@
                     </p>
                 </div>
 
-                {% if progress_snapshot.best_day.goal > 0 %}
-                    <div class="weekly-insight-detail">
-                        <span class="weekly-insight-detail-label">Best day</span>
-                        <strong>{{ progress_snapshot.best_day.label }}</strong>
-                        <span>
-                            {{ progress_snapshot.best_day.completed }}/{{ progress_snapshot.best_day.goal }}
-                            habits completed
-                        </span>
-                    </div>
-                {% endif %}
+                <div class="weekly-insight-detail">
+                    <span class="weekly-insight-detail-label">Top habit</span>
+                    <strong>{{ progress_snapshot.top_habit.name }}</strong>
+                    <span>{{ progress_snapshot.top_habit.summary }}</span>
+                    <span class="weekly-insight-note">
+                        {{ progress_snapshot.top_habit.detail }}
+                    </span>
+                </div>
             {% else %}
                 <div class="weekly-insight-empty">
                     <strong>No scheduled habit data yet</strong>

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -365,13 +365,13 @@
         </section>
 
         <section class="dash-card mt-4">
-            <div class="d-flex justify-content-between align-items-center mb-3">
+            <div class="active-preview-header d-flex justify-content-between align-items-center mb-3">
                 <div>
                     <h3>Active Habits Preview</h3>
                     <p class="text-muted mb-0">A quick look at today's active habits. Open the full page to manage everything.</p>
                 </div>
 
-                <div class="d-flex gap-2">
+                <div class="active-preview-actions d-flex gap-2">
                     <a href="/active_habits" class="btn btn-outline-primary">
                         View All Habits
                     </a>

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -80,6 +80,46 @@
             </div>
         </div>
 
+        <section class="weekly-insight-card">
+            <div class="weekly-insight-copy">
+                <span class="hero-badge">Weekly Insight</span>
+                <h2>Weekly completion</h2>
+                <p>
+                    This dashboard score averages your completion rate across days
+                    that had scheduled habits.
+                </p>
+            </div>
+
+            {% if progress_snapshot.has_scheduled_data %}
+                <div class="weekly-insight-metric">
+                    <p class="weekly-insight-label">This week</p>
+                    <h3>{{ progress_snapshot.weekly_average }}%</h3>
+                    <p class="weekly-insight-trend mb-0">
+                        {{ progress_snapshot.weekly_change_summary }}
+                    </p>
+                </div>
+
+                {% if progress_snapshot.best_day.goal > 0 %}
+                    <div class="weekly-insight-detail">
+                        <span class="weekly-insight-detail-label">Best day</span>
+                        <strong>{{ progress_snapshot.best_day.label }}</strong>
+                        <span>
+                            {{ progress_snapshot.best_day.completed }}/{{ progress_snapshot.best_day.goal }}
+                            habits completed
+                        </span>
+                    </div>
+                {% endif %}
+            {% else %}
+                <div class="weekly-insight-empty">
+                    <strong>No scheduled habit data yet</strong>
+                    <span>
+                        Add or schedule a few habits and your weekly completion score
+                        will start showing here.
+                    </span>
+                </div>
+            {% endif %}
+        </section>
+
         <div class="dashboard-grid">
 
             <section class="dash-card">

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -93,6 +93,7 @@
         </div>
 
         <div class="analytics-grid">
+            <div class="analytics-primary-column">
             <section class="weekly-trend-card">
                 <div class="weekly-trend-header">
                     <div>
@@ -147,6 +148,79 @@
                 {% endif %}
             </section>
 
+            <section class="dash-card streak-card">
+                <div class="streak-card-header">
+                    <div>
+                        <h3>Streak momentum</h3>
+                        <p class="mb-0">{{ progress_snapshot.streak_summary.headline }}</p>
+                    </div>
+                    <span class="streak-chip">
+                        {{ progress_snapshot.streak_summary.current }}
+                        day{% if progress_snapshot.streak_summary.current != 1 %}s{% endif %} streak
+                    </span>
+                </div>
+
+                <div class="streak-progress-block">
+                    <span class="streak-progress-label">Current streak</span>
+                    <div class="streak-progress-topline">
+                        <strong>
+                            {{ progress_snapshot.streak_summary.current }}
+                            day{% if progress_snapshot.streak_summary.current != 1 %}s{% endif %}
+                        </strong>
+                        <span>{{ progress_snapshot.streak_summary.next_milestone_label }}</span>
+                    </div>
+
+                    <div class="streak-progress-track" aria-hidden="true">
+                        <div
+                            class="streak-progress-fill"
+                            style="width: {{ progress_snapshot.streak_summary.progress_percentage }}%;"
+                        ></div>
+                    </div>
+
+                    <div class="streak-progress-scale">
+                        <span></span>
+                        <span>{{ progress_snapshot.streak_summary.next_goal }} day goal</span>
+                    </div>
+                </div>
+
+                <div class="streak-card-notes">
+                    <article class="streak-note-card">
+                        <span>Next milestone</span>
+                        <strong>{{ progress_snapshot.streak_summary.next_goal }} days</strong>
+                        <small>{{ progress_snapshot.streak_summary.detail }}</small>
+                    </article>
+
+                    <article class="streak-note-card">
+                        <span>{{ progress_snapshot.streak_summary.personal_best_label }}</span>
+                        <strong>
+                            {% if progress_snapshot.streak_summary.days_to_personal_best == 0 %}
+                                {{ progress_snapshot.streak_summary.personal_best }} days
+                            {% else %}
+                                {{ progress_snapshot.streak_summary.days_to_personal_best }} day{% if progress_snapshot.streak_summary.days_to_personal_best != 1 %}s{% endif %}
+                            {% endif %}
+                        </strong>
+                        <small>{{ progress_snapshot.streak_summary.personal_best_detail }}</small>
+                    </article>
+
+                    <article class="streak-note-card">
+                        <span>Habit carrying the streak</span>
+                        <strong>{{ progress_snapshot.streak_summary.carrying_habit_name }}</strong>
+                        <small>{{ progress_snapshot.streak_summary.carrying_habit_detail }}</small>
+                    </article>
+
+                    <article class="streak-note-card">
+                        <span>Weekly completion trend</span>
+                        <strong>{{ progress_snapshot.streak_summary.weekly_completion_value }}%</strong>
+                        <small>{{ progress_snapshot.streak_summary.weekly_completion_trend }}</small>
+                    </article>
+                </div>
+
+                <p class="streak-card-detail mb-0">
+                    Keep the streak moving and this card will keep updating your next milestone, personal-best pace, and the habit driving the run.
+                </p>
+            </section>
+            </div>
+
         <section class="focus-panel-card">
             <div class="focus-panel-header">
                 <div>
@@ -185,6 +259,16 @@
                                 </a>
                             </article>
                         {% endfor %}
+
+                        {% if progress_snapshot.focus_items|length < 3 %}
+                            <div class="focus-panel-placeholder">
+                                <span class="focus-panel-placeholder-label">Steady pace</span>
+                                <h4>More room for wins</h4>
+                                <p class="mb-0">
+                                    This space stays open when fewer habits need attention, which usually means your week is tracking well.
+                                </p>
+                            </div>
+                        {% endif %}
                     </div>
                 {% else %}
                     <div class="focus-panel-empty">
@@ -198,38 +282,6 @@
         </div>
 
         <div class="dashboard-grid">
-
-            <section class="dash-card today-snapshot-card">
-                <h3>Today snapshot</h3>
-
-                {% if total > 0 %}
-                    <div class="today-snapshot-list">
-                        <div class="today-snapshot-item">
-                            <span>Remaining today</span>
-                            <strong>{{ reminders|length }}</strong>
-                        </div>
-
-                        <div class="today-snapshot-item">
-                            <span>Current streak</span>
-                            <strong>{{ progress_snapshot.current_streak }}</strong>
-                        </div>
-
-                        <div class="today-snapshot-item">
-                            <span>Weekly score</span>
-                            <strong>{{ progress_snapshot.weekly_average }}%</strong>
-                        </div>
-                    </div>
-
-                    <p class="text-muted mb-0">
-                        Visit Active Habits to finish today's check-ins or update what still needs attention.
-                    </p>
-                {% else %}
-                    <p class="mb-0">
-                        Nothing is scheduled for today yet. Add a habit or adjust a schedule to start building today's snapshot.
-                    </p>
-                {% endif %}
-            </section>
-
             <section class="dash-card health-profile-card">
                 <div class="health-profile-header">
                     <div>

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -78,6 +78,14 @@
                     <span>Daily movement</span>
                 </div>
             </div>
+            <div class="summary-card red">
+                <div class="summary-icon">!</div>
+                <div>
+                    <p>At Risk</p>
+                    <h2>{{ progress_snapshot.at_risk.count }}</h2>
+                    <span>{{ progress_snapshot.at_risk.summary }}</span>
+                </div>
+            </div>
         </div>
 
         <section class="weekly-insight-card">

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -35,7 +35,7 @@
         <div class="dashboard-top">
             <div>
                 <h1>Welcome back, {{ session["user_name"] }} 👋</h1>
-                <p>Stay consistent and crush your goals today.</p>
+                <p>Your habits, momentum, and daily check-ins are all in one place.</p>
             </div>
 
             <div class="date-pill">
@@ -68,9 +68,9 @@
 
                     <span class="split-card-detail">
                         {% if total > 0 %}
-                            {{ completed }}/{{ total }} active habits are done today.
+                            {{ completed }}/{{ total }} active habits are checked off today.
                         {% else %}
-                            No active habits are scheduled today.
+                            Nothing is scheduled for today yet.
                         {% endif %}
                     </span>
                 </div>
@@ -79,13 +79,13 @@
             <div class="summary-card blue summary-card-stacked">
                 <div class="summary-icon">📈</div>
                 <div>
-                    <p>Completion Rate</p>
+                    <p>Weekly Completion</p>
                     <h2>{{ progress_snapshot.weekly_average }}%</h2>
                     <span>
                         {% if progress_snapshot.has_scheduled_data %}
-                            Across scheduled habits this week. {{ progress_snapshot.weekly_change_summary }}
+                            Based on scheduled habits from Sunday through today. {{ progress_snapshot.weekly_change_summary }}
                         {% else %}
-                            Weekly momentum will appear once habits are scheduled.
+                            Weekly progress will appear once this week has scheduled check-ins.
                         {% endif %}
                     </span>
                 </div>
@@ -98,8 +98,8 @@
                     <div>
                         <h3>Weekly trend</h3>
                         <p class="mb-0">
-                            A Sun-Sat view of completed habits versus the habits that
-                            were scheduled each day this week.
+                            A Sunday-to-Saturday view of what was scheduled and what
+                            got done this week.
                         </p>
                     </div>
 
@@ -140,8 +140,8 @@
                     <div class="weekly-trend-empty">
                         <strong>No weekly trend yet</strong>
                         <span>
-                            Once your habits have scheduled check-ins, this chart will
-                            start showing how each day is tracking.
+                            This chart will start filling in once this week has scheduled
+                            habit check-ins to measure against.
                         </span>
                     </div>
                 {% endif %}
@@ -152,15 +152,22 @@
                 <div>
                     <h3>Focus this week</h3>
                     <p class="mb-0">
-                        The three habits most worth attention right now.
+                        The habits most worth a quick check-in right now.
                     </p>
                 </div>
             </div>
 
                 <div class="focus-panel-highlight">
-                    <span class="focus-panel-highlight-label">Leading this week</span>
+                    <span class="focus-panel-highlight-label">
+                        {% if progress_snapshot.top_habit.has_data %}Leading this week{% else %}Top habit preview{% endif %}
+                    </span>
                     <strong>{{ progress_snapshot.top_habit.name }}</strong>
-                    <small>{{ progress_snapshot.top_habit.summary }}</small>
+                    <small>
+                        {{ progress_snapshot.top_habit.summary }}
+                        {% if not progress_snapshot.top_habit.has_data %}
+                            {{ progress_snapshot.top_habit.detail }}
+                        {% endif %}
+                    </small>
                 </div>
 
                 {% if progress_snapshot.focus_items %}
@@ -181,9 +188,9 @@
                     </div>
                 {% else %}
                     <div class="focus-panel-empty">
-                        <h4>Strong week so far</h4>
+                        <h4>Nothing urgent right now</h4>
                         <p class="mb-0">
-                            Nothing is currently due, below pace, or losing momentum.
+                            Your habits are on track right now, so this space will stay quiet until something needs attention.
                         </p>
                     </div>
                 {% endif %}
@@ -214,11 +221,11 @@
                     </div>
 
                     <p class="text-muted mb-0">
-                        Open your active habits to check off or adjust what is left for today.
+                        Visit Active Habits to finish today's check-ins or update what still needs attention.
                     </p>
                 {% else %}
                     <p class="mb-0">
-                        No active habits are scheduled today. Add one or update a schedule to get started.
+                        Nothing is scheduled for today yet. Add a habit or adjust a schedule to start building today's snapshot.
                     </p>
                 {% endif %}
             </section>
@@ -361,7 +368,7 @@
             <div class="d-flex justify-content-between align-items-center mb-3">
                 <div>
                     <h3>Active Habits Preview</h3>
-                    <p class="text-muted mb-0">A quick look at today’s active habits. Open the full page to manage everything.</p>
+                    <p class="text-muted mb-0">A quick look at today's active habits. Open the full page to manage everything.</p>
                 </div>
 
                 <div class="d-flex gap-2">
@@ -376,7 +383,7 @@
             </div>
 
             {% set habits = preview_habits %}
-            {% set empty_message = "No active habits for today." %}
+            {% set empty_message = "No active habits are scheduled for today yet." %}
             {% include "_habit_list.html" %}
 
             {% if total > preview_habits|length %}
@@ -394,3 +401,4 @@
 
 </body>
 </html>
+

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -176,6 +176,47 @@
             {% endif %}
         </section>
 
+        <section class="focus-panel-card">
+            <div class="focus-panel-header">
+                <div>
+                    <h3>Focus this week</h3>
+                    <p class="mb-0">
+                        Review the habits that are due today, below pace, or
+                        cooling off.
+                    </p>
+                </div>
+
+                <span class="focus-panel-count">
+                    {{ progress_snapshot.at_risk.count }} flagged
+                </span>
+            </div>
+
+            {% if progress_snapshot.focus_items %}
+                <div class="focus-panel-list">
+                    {% for habit in progress_snapshot.focus_items %}
+                        <article class="focus-panel-item">
+                            <div>
+                                <span class="focus-panel-reason">{{ habit.reason }}</span>
+                                <h4>{{ habit.name }}</h4>
+                                <p class="mb-0">{{ habit.detail }}</p>
+                            </div>
+
+                            <a href="/active_habits" class="btn btn-sm btn-outline-primary">
+                                Review
+                            </a>
+                        </article>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="focus-panel-empty">
+                    <h4>Strong week so far</h4>
+                    <p class="mb-0">
+                        Nothing is currently due, below pace, or losing momentum.
+                    </p>
+                </div>
+            {% endif %}
+        </section>
+
         <div class="dashboard-grid">
 
             <section class="dash-card">

--- a/Habit-tracker/templates/dashboard.html
+++ b/Habit-tracker/templates/dashboard.html
@@ -53,184 +53,173 @@
                 </div>
             </div>
 
-            <div class="summary-card green">
+            <div class="summary-card split-card">
                 <div class="summary-icon">✓</div>
-                <div>
-                    <p>Completed Today</p>
-                    <h2>{{ completed }}</h2>
-                    <span>Keep going</span>
+                <div class="split-card-content">
+                    <p class="split-card-title">Today</p>
+
+                    <div class="split-card-metrics">
+                        <div class="split-card-metric">
+                            <span class="split-card-label">Completed</span>
+                            <strong>{{ completed }}</strong>
+                        </div>
+
+                    </div>
+
+                    <span class="split-card-detail">
+                        {% if total > 0 %}
+                            {{ completed }}/{{ total }} active habits are done today.
+                        {% else %}
+                            No active habits are scheduled today.
+                        {% endif %}
+                    </span>
                 </div>
             </div>
 
-            <div class="summary-card blue">
+            <div class="summary-card blue summary-card-stacked">
                 <div class="summary-icon">📈</div>
                 <div>
                     <p>Completion Rate</p>
-                    <h2>{{ percentage }}%</h2>
-                </div>
-            </div>
-
-            <div class="summary-card orange">
-                <div class="summary-icon">👟</div>
-                <div>
-                    <p>Steps Today</p>
-                    <h2>{{ today_steps }}</h2>
-                    <span>Daily movement</span>
-                </div>
-            </div>
-            <div class="summary-card red">
-                <div class="summary-icon">!</div>
-                <div>
-                    <p>At Risk</p>
-                    <h2>{{ progress_snapshot.at_risk.count }}</h2>
-                    <span>{{ progress_snapshot.at_risk.summary }}</span>
+                    <h2>{{ progress_snapshot.weekly_average }}%</h2>
+                    <span>
+                        {% if progress_snapshot.has_scheduled_data %}
+                            Across scheduled habits this week. {{ progress_snapshot.weekly_change_summary }}
+                        {% else %}
+                            Weekly momentum will appear once habits are scheduled.
+                        {% endif %}
+                    </span>
                 </div>
             </div>
         </div>
 
-        <section class="weekly-insight-card">
-            <div class="weekly-insight-copy">
-                <span class="hero-badge">Weekly Insight</span>
-                <h2>Weekly completion</h2>
-                <p>
-                    This dashboard score averages your completion rate across days
-                    that had scheduled habits.
-                </p>
-            </div>
+        <div class="analytics-grid">
+            <section class="weekly-trend-card">
+                <div class="weekly-trend-header">
+                    <div>
+                        <h3>Weekly trend</h3>
+                        <p class="mb-0">
+                            A Sun-Sat view of completed habits versus the habits that
+                            were scheduled each day this week.
+                        </p>
+                    </div>
 
-            {% if progress_snapshot.has_scheduled_data %}
-                <div class="weekly-insight-metric">
-                    <p class="weekly-insight-label">This week</p>
-                    <h3>{{ progress_snapshot.weekly_average }}%</h3>
-                    <p class="weekly-insight-trend mb-0">
-                        {{ progress_snapshot.weekly_change_summary }}
-                    </p>
+                    {% if progress_snapshot.has_scheduled_data and progress_snapshot.best_day.goal > 0 %}
+                        <div class="weekly-trend-badge">
+                            <span>Best day</span>
+                            <strong>{{ progress_snapshot.best_day.label }}</strong>
+                            <small>
+                                {{ progress_snapshot.best_day.completed }}/{{ progress_snapshot.best_day.goal }}
+                                completed
+                            </small>
+                        </div>
+                    {% endif %}
                 </div>
 
-                <div class="weekly-insight-detail">
-                    <span class="weekly-insight-detail-label">Top habit</span>
-                    <strong>{{ progress_snapshot.top_habit.name }}</strong>
-                    <span>{{ progress_snapshot.top_habit.summary }}</span>
-                    <span class="weekly-insight-note">
-                        {{ progress_snapshot.top_habit.detail }}
-                    </span>
-                </div>
-            {% else %}
-                <div class="weekly-insight-empty">
-                    <strong>No scheduled habit data yet</strong>
-                    <span>
-                        Add or schedule a few habits and your weekly completion score
-                        will start showing here.
-                    </span>
-                </div>
-            {% endif %}
-        </section>
-
-        <section class="weekly-trend-card">
-            <div class="weekly-trend-header">
-                <div>
-                    <h3>Weekly trend</h3>
-                    <p class="mb-0">
-                        A 7-day view of completed habits versus the habits that were
-                        scheduled each day this week.
-                    </p>
-                </div>
-
-                {% if progress_snapshot.has_scheduled_data and progress_snapshot.best_day.goal > 0 %}
-                    <div class="weekly-trend-badge">
-                        <span>Best day</span>
-                        <strong>{{ progress_snapshot.best_day.label }}</strong>
-                        <small>
-                            {{ progress_snapshot.best_day.completed }}/{{ progress_snapshot.best_day.goal }}
-                            completed
-                        </small>
+                {% if progress_snapshot.has_scheduled_data %}
+                    <div class="weekly-bars">
+                        {% for day in progress_snapshot.weekly_progress %}
+                            <div class="weekly-bar-group {% if day.is_future %}future{% endif %}">
+                                <div class="weekly-bar-track">
+                                    <div
+                                        class="weekly-bar-fill {% if day.goal == 0 %}empty{% elif day.percentage == 0 %}zero{% endif %}"
+                                        style="height: {% if day.goal == 0 %}0{% elif day.percentage == 0 %}12px{% else %}{{ day.percentage }}%{% endif %};"
+                                        title="{% if day.is_future %}Upcoming day{% else %}{{ day.percentage }}% ({{ day.completed }}/{{ day.goal }}){% endif %}"
+                                    ></div>
+                                </div>
+                                <p class="weekly-bar-percent">
+                                    {% if day.is_future %}--{% else %}{{ day.percentage }}%{% endif %}
+                                </p>
+                                <p class="weekly-bar-value">
+                                    {% if day.is_future %}Upcoming{% else %}{{ day.completed }}/{{ day.goal }}{% endif %}
+                                </p>
+                                <p class="weekly-bar-label mb-0">{{ day.label }}</p>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="weekly-trend-empty">
+                        <strong>No weekly trend yet</strong>
+                        <span>
+                            Once your habits have scheduled check-ins, this chart will
+                            start showing how each day is tracking.
+                        </span>
                     </div>
                 {% endif %}
-            </div>
-
-            {% if progress_snapshot.has_scheduled_data %}
-                <div class="weekly-bars">
-                    {% for day in progress_snapshot.weekly_progress %}
-                        <div class="weekly-bar-group">
-                            <div class="weekly-bar-track">
-                                <div
-                                    class="weekly-bar-fill {% if day.goal == 0 %}empty{% elif day.percentage == 0 %}zero{% endif %}"
-                                    style="height: {% if day.goal == 0 %}0{% elif day.percentage == 0 %}12px{% else %}{{ day.percentage }}%{% endif %};"
-                                    title="{{ day.percentage }}% ({{ day.completed }}/{{ day.goal }})"
-                                ></div>
-                            </div>
-                            <p class="weekly-bar-percent">{{ day.percentage }}%</p>
-                            <p class="weekly-bar-value">{{ day.completed }}/{{ day.goal }}</p>
-                            <p class="weekly-bar-label mb-0">{{ day.label }}</p>
-                        </div>
-                    {% endfor %}
-                </div>
-            {% else %}
-                <div class="weekly-trend-empty">
-                    <strong>No weekly trend yet</strong>
-                    <span>
-                        Once your habits have scheduled check-ins, this chart will
-                        start showing how each day is tracking.
-                    </span>
-                </div>
-            {% endif %}
-        </section>
+            </section>
 
         <section class="focus-panel-card">
             <div class="focus-panel-header">
                 <div>
                     <h3>Focus this week</h3>
                     <p class="mb-0">
-                        Review the habits that are due today, below pace, or
-                        cooling off.
+                        The three habits most worth attention right now.
                     </p>
                 </div>
-
-                <span class="focus-panel-count">
-                    {{ progress_snapshot.at_risk.count }} flagged
-                </span>
             </div>
 
-            {% if progress_snapshot.focus_items %}
-                <div class="focus-panel-list">
-                    {% for habit in progress_snapshot.focus_items %}
-                        <article class="focus-panel-item">
-                            <div>
-                                <span class="focus-panel-reason">{{ habit.reason }}</span>
-                                <h4>{{ habit.name }}</h4>
-                                <p class="mb-0">{{ habit.detail }}</p>
-                            </div>
+                <div class="focus-panel-highlight">
+                    <span class="focus-panel-highlight-label">Leading this week</span>
+                    <strong>{{ progress_snapshot.top_habit.name }}</strong>
+                    <small>{{ progress_snapshot.top_habit.summary }}</small>
+                </div>
 
-                            <a href="/active_habits" class="btn btn-sm btn-outline-primary">
-                                Review
-                            </a>
-                        </article>
-                    {% endfor %}
-                </div>
-            {% else %}
-                <div class="focus-panel-empty">
-                    <h4>Strong week so far</h4>
-                    <p class="mb-0">
-                        Nothing is currently due, below pace, or losing momentum.
-                    </p>
-                </div>
-            {% endif %}
-        </section>
+                {% if progress_snapshot.focus_items %}
+                    <div class="focus-panel-list">
+                        {% for habit in progress_snapshot.focus_items %}
+                            <article class="focus-panel-item">
+                                <div>
+                                    <span class="focus-panel-reason">{{ habit.reason }}</span>
+                                    <h4>{{ habit.name }}</h4>
+                                    <p class="mb-0">{{ habit.detail }}</p>
+                                </div>
+
+                                <a href="/active_habits" class="btn btn-sm btn-outline-primary">
+                                    Review
+                                </a>
+                            </article>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="focus-panel-empty">
+                        <h4>Strong week so far</h4>
+                        <p class="mb-0">
+                            Nothing is currently due, below pace, or losing momentum.
+                        </p>
+                    </div>
+                {% endif %}
+            </section>
+        </div>
 
         <div class="dashboard-grid">
 
-            <section class="dash-card">
-                <h3>🔔 Reminder</h3>
+            <section class="dash-card today-snapshot-card">
+                <h3>Today snapshot</h3>
 
-                {% if reminders %}
-                    <p>You still have unfinished habits:</p>
-                    <ul>
-                        {% for reminder in reminders %}
-                            <li>{{ reminder[1] }}</li>
-                        {% endfor %}
-                    </ul>
+                {% if total > 0 %}
+                    <div class="today-snapshot-list">
+                        <div class="today-snapshot-item">
+                            <span>Remaining today</span>
+                            <strong>{{ reminders|length }}</strong>
+                        </div>
+
+                        <div class="today-snapshot-item">
+                            <span>Current streak</span>
+                            <strong>{{ progress_snapshot.current_streak }}</strong>
+                        </div>
+
+                        <div class="today-snapshot-item">
+                            <span>Weekly score</span>
+                            <strong>{{ progress_snapshot.weekly_average }}%</strong>
+                        </div>
+                    </div>
+
+                    <p class="text-muted mb-0">
+                        Open your active habits to check off or adjust what is left for today.
+                    </p>
                 {% else %}
-                    <p>Great job! Everything is completed today 🎉</p>
+                    <p class="mb-0">
+                        No active habits are scheduled today. Add one or update a schedule to get started.
+                    </p>
                 {% endif %}
             </section>
 


### PR DESCRIPTION
## Summary
Adds a richer dashboard experience so users can track weekly momentum, streak progress, and habits that need attention without leaving the dashboard.

## What Changed
- added shared dashboard analytics logic and progress snapshot data
- added `Weekly trend` and `Focus this week` sections
- added fair top-habit and at-risk habit logic
- added a new `Streak momentum` card with:
  - current streak
  - next milestone
  - days to personal best
  - habit carrying the streak
  - weekly completion trend
- polished dashboard copy, spacing, layout, and responsive styling

## Reviewer Checks
1. Open `/dashboard` and confirm the new progress sections appear:
   - `Weekly trend`
   - `Focus this week`
   - `Streak momentum`

2. Check that `Weekly trend` displays days in `Sun` to `Sat` order.

3. Confirm future days in the weekly trend do not look like failed days.

4. Verify `Focus this week` shows actionable habits when some are due or below pace.

5. Verify `Streak momentum` updates with:
   - current streak
   - next milestone
   - personal-best distance
   - carrying habit
   - weekly completion trend

6. Resize to a smaller/mobile viewport and confirm the dashboard stacks cleanly.

## Manual Checks
- ran `python -m py_compile Habit-tracker/app.py`
- loaded `/dashboard` successfully with HTTP `200`
